### PR TITLE
Fixed Quaternion Division

### DIFF
--- a/OpenGL/Math/Quaternion.cs
+++ b/OpenGL/Math/Quaternion.cs
@@ -82,7 +82,7 @@ namespace OpenGL
         public static Quaternion operator /(Quaternion q, float scalar)
         {
             float invScalar = 1.0f / scalar;
-            return new Quaternion(q.x * invScalar, q.y + invScalar, q.z * invScalar, q.w * invScalar);
+            return new Quaternion(q.x * invScalar, q.y * invScalar, q.z * invScalar, q.w * invScalar);
         }
 
         public static Quaternion operator /(Quaternion q1, Quaternion q2)


### PR DESCRIPTION
There was a bug with quaternion division where the Y value would be added to the inverse scalar instead of multiplied by it.
