### PR TITLE
Update Shader.cs to fix documentation

### DIFF
--- a/OpenGL/Constructs/Shader.cs
+++ b/OpenGL/Constructs/Shader.cs
@@ -315,7 +315,7 @@ namespace OpenGL
         }
 
         /// <summary>
-        /// Returns Gl.GetShaderInfoLog(ShaderID), which contains any linking errors.
+        /// Returns Gl.GetProgramInfoLog(ProgramID), which contains any linking errors.
         /// </summary>
         public string ProgramLog
         {


### PR DESCRIPTION
Fixes the documentation on Shader.ProgramLog that was apparently(?) copied from Shader.ShaderLog.
