### PR TITLE
Throw exception when shader compiling or linking fails

### DIFF
--- a/OpenGL/Constructs/Shader.cs
+++ b/OpenGL/Constructs/Shader.cs
@@ -230,6 +230,13 @@ namespace OpenGL
 
             Gl.ShaderSource(ShaderID, source);
             Gl.CompileShader(ShaderID);
+
+            //Check whether the shader compiled successfully.
+            //If not then throw an error with the compile error.
+            if (!Gl.GetShaderCompileStatus(ShaderID))
+            {
+                throw new Exception(ShaderLog);
+            }
         }
 
         ~Shader()
@@ -343,6 +350,13 @@ namespace OpenGL
             Gl.AttachShader(ProgramID, vertexShader.ShaderID);
             Gl.AttachShader(ProgramID, fragmentShader.ShaderID);
             Gl.LinkProgram(ProgramID);
+
+            //Check whether the program linked successfully.
+            //If not then throw an error with the linking error.
+            if (!Gl.GetProgramLinkStatus(ProgramID))
+            {
+                throw new Exception(ProgramLog);
+            }
 
             GetParams();
         }

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -265,6 +265,30 @@ namespace OpenGL
         }
 
         /// <summary>
+        /// Gets whether the shader compiled successfully.
+        /// </summary>
+        /// <param name="shader">The ID of the shader program.</param>
+        /// <returns></returns>
+        public static bool GetShaderCompileStatus(UInt32 shader)
+        {
+            const int SUCCESS = 1;
+            Gl.GetShaderiv(shader, ShaderParameter.CompileStatus, int1);
+            return int1[0] == SUCCESS;
+        }
+
+        /// <summary>
+        /// Get whether program linking was performed successfully.
+        /// </summary>
+        /// <param name="program"></param>
+        /// <returns></returns>
+        public static bool GetProgramLinkStatus(UInt32 program)
+        {
+            const int SUCCESS = 1;
+            Gl.GetProgramiv(program, ProgramParameter.LinkStatus, int1);
+            return int1[0] == SUCCESS;
+        }
+
+        /// <summary>
         /// Gets the program info from a shader program.
         /// </summary>
         /// <param name="program">The ID of the shader program.</param>


### PR DESCRIPTION
Uhh i somehow messed up so badly that i had to create a whole new pr. Sorry about that. Previous pr was #15.

So i did as you requested. pr is updated with thew newest changes from the dotnetcore branch. Code is now using ´´´ShaderLog´´´ and ´´´ProgramLog´´´. I moved some of the code into GlMethods.cs so the preallocated arrays could be used. Last i added a few comments and method descriptions.

Offtopic
Hopefully it all works now. I have few other changes i can commit soon but before i do that i wanted to ask you if there is any unit tests for the dotnetcore branch? I made a Matrix2 class that seems to work correct but i am sure you would like it if such a pr came with tests.