### PR TITLE
Support additional numerical types

### DIFF
--- a/OpenGL/Core/GlEnum.cs
+++ b/OpenGL/Core/GlEnum.cs
@@ -2682,7 +2682,8 @@ namespace OpenGL
         Double = ((int)0x140A),
         HalfFloat = ((int)0x140B),
         UnsignedUInt2101010Reversed = ((int)0x8368),
-        UnsignedInt2101010Reversed = ((int)0x8D9F)
+        UnsignedInt2101010Reversed = ((int)0x8D9F),
+        UnsignedUInt101111Reversed = ((int)0x8C3B)
     }
 #pragma warning restore
 }


### PR DESCRIPTION
VBO now support these additional types: ```sbyte```, ```byte```, ```short```, ```ushort```, ```int```, ```uint```, ```float``` and ```double```.
Added the following properties to VBO.
```bool CastToFloat```: All supported types may be cast to float on the gpu. So an int and double will be converted to floats. If this is false then other types than float will not be cast to float. If you wish to use a vertex attribute of an integral type then this should be false.
```bool Normalize```: Whether integral types should be normalized when cast to float.

### Breaking changes
VAO now supports an element array with another type than int. You now has to specify which type the element array will be in the VAO type. So previous ```VAO<Vector3>``` is now ```VAO<Vector3, uint>``` Signed integral types are not valid element buffer types. I can move this part to its own pr if necessary.

Removed Divisor from the constructors of VBO. Divisor, along with CastToFloat and Normalize, are not part of the constructor. Instead of cluttering the constructors i decided to keep them as simple properties. I think it makes sense if all properties, that can be changed from outside the VBO, aren't part of the constructor. So essentially only readonly properties are part of the constructor.
