### PR TITLE
Added attribute name caching to BindBufferToShaderAttribute

### DIFF
--- a/OpenGL/Constructs/Shader.cs
+++ b/OpenGL/Constructs/Shader.cs
@@ -562,8 +562,6 @@ namespace OpenGL
                 Gl.DetachShader(ProgramID, VertexShader.ShaderID);
                 Gl.DetachShader(ProgramID, FragmentShader.ShaderID);
                 Gl.DeleteProgram(ProgramID);
-                // Remove attribute names cache
-                Gl.shaderProgramAttributeNamesCache.Remove(ProgramID);
 
                 if (DisposeChildren)
                 {

--- a/OpenGL/Constructs/Shader.cs
+++ b/OpenGL/Constructs/Shader.cs
@@ -562,6 +562,8 @@ namespace OpenGL
                 Gl.DetachShader(ProgramID, VertexShader.ShaderID);
                 Gl.DetachShader(ProgramID, FragmentShader.ShaderID);
                 Gl.DeleteProgram(ProgramID);
+                // Remove attribute names cache
+                Gl.shaderProgramAttributeNamesCache.Remove(ProgramID);
 
                 if (DisposeChildren)
                 {

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -716,7 +716,7 @@ namespace OpenGL
         }
 
         // Every shader program has a dictionary with the attribute names and attribute IDs.
-        private static Dictionary<uint, Dictionary<string, uint>> shaderProgramAttributeNamesCache = new Dictionary<uint, Dictionary<string, uint>>();
+        internal static Dictionary<uint, Dictionary<string, uint>> shaderProgramAttributeNamesCache = new Dictionary<uint, Dictionary<string, uint>>();
 
         /// <summary>
         /// Binds a VBO to a shader attribute.

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 #if USE_NUMERICS
@@ -714,6 +715,9 @@ namespace OpenGL
             Gl.BindBuffer(buffer.BufferTarget, buffer.ID);
         }
 
+        // Every shader program has a dictionary with the attribute names and attribute IDs.
+        private static Dictionary<uint, Dictionary<string, uint>> shaderProgramAttributeNamesCache = new Dictionary<uint, Dictionary<string, uint>>();
+
         /// <summary>
         /// Binds a VBO to a shader attribute.
         /// </summary>
@@ -723,7 +727,20 @@ namespace OpenGL
         public static void BindBufferToShaderAttribute<T>(VBO<T> buffer, ShaderProgram program, string attributeName)
             where T : struct
         {
-            uint location = (uint)Gl.GetAttribLocation(program.ProgramID, attributeName);
+            // Create and get a dictionary for the current shader program.
+            if(!shaderProgramAttributeNamesCache.ContainsKey(program.ProgramID))
+            {
+                shaderProgramAttributeNamesCache[program.ProgramID] = new Dictionary<string, uint>();
+            }
+            Dictionary<string, uint> attributeNamesCache = shaderProgramAttributeNamesCache[program.ProgramID];
+
+            // Cache the attribute location with the attribute name.
+            if(!attributeNamesCache.ContainsKey(attributeName))
+            {
+                attributeNamesCache[attributeName] = (uint)Gl.GetAttribLocation(program.ProgramID, attributeName);
+            }
+
+            uint location = attributeNamesCache[attributeName];
 
             Gl.EnableVertexAttribArray(location);
             Gl.BindBuffer(buffer);

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -728,11 +728,12 @@ namespace OpenGL
             where T : struct
         {
             // Create and get a dictionary for the current shader program.
-            if(!shaderProgramAttributeNamesCache.ContainsKey(program.ProgramID))
+            Dictionary<string, uint> attributeNamesCache;
+            if(!shaderProgramAttributeNamesCache.TryGetValue(program.ProgramID, out attributeNamesCache))
             {
-                shaderProgramAttributeNamesCache[program.ProgramID] = new Dictionary<string, uint>();
+                attributeNamesCache = new Dictionary<string, uint>();
+                shaderProgramAttributeNamesCache[program.ProgramID] = attributeNamesCache;
             }
-            Dictionary<string, uint> attributeNamesCache = shaderProgramAttributeNamesCache[program.ProgramID];
 
             // Cache the attribute location with the attribute name.
             if(!attributeNamesCache.ContainsKey(attributeName))

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -715,9 +715,6 @@ namespace OpenGL
             Gl.BindBuffer(buffer.BufferTarget, buffer.ID);
         }
 
-        // Every shader program has a dictionary with the attribute names and attribute IDs.
-        internal static Dictionary<uint, Dictionary<string, uint>> shaderProgramAttributeNamesCache = new Dictionary<uint, Dictionary<string, uint>>();
-
         /// <summary>
         /// Binds a VBO to a shader attribute.
         /// </summary>
@@ -727,21 +724,10 @@ namespace OpenGL
         public static void BindBufferToShaderAttribute<T>(VBO<T> buffer, ShaderProgram program, string attributeName)
             where T : struct
         {
-            // Create and get a dictionary for the current shader program.
-            Dictionary<string, uint> attributeNamesCache;
-            if(!shaderProgramAttributeNamesCache.TryGetValue(program.ProgramID, out attributeNamesCache))
-            {
-                attributeNamesCache = new Dictionary<string, uint>();
-                shaderProgramAttributeNamesCache[program.ProgramID] = attributeNamesCache;
-            }
-
-            // Cache the attribute location with the attribute name.
-            uint location;
-            if(!attributeNamesCache.TryGetValue(attributeName, out location))
-            {
-                location = (uint)Gl.GetAttribLocation(program.ProgramID, attributeName);
-                attributeNamesCache[attributeName] = location;
-            }
+            var cachedAttribute = program[attributeName];
+            if(cachedAttribute == null)
+                throw new ArgumentException($"{attributeName} did not exist in the shader.", nameof(attributeName));
+            uint location = (uint)cachedAttribute.Location;
 
             Gl.EnableVertexAttribArray(location);
             Gl.BindBuffer(buffer);

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 #if USE_NUMERICS

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -736,12 +736,12 @@ namespace OpenGL
             }
 
             // Cache the attribute location with the attribute name.
-            if(!attributeNamesCache.ContainsKey(attributeName))
+            uint location;
+            if(!attributeNamesCache.TryGetValue(attributeName, out location))
             {
-                attributeNamesCache[attributeName] = (uint)Gl.GetAttribLocation(program.ProgramID, attributeName);
+                location = (uint)Gl.GetAttribLocation(program.ProgramID, attributeName);
+                attributeNamesCache[attributeName] = location;
             }
-
-            uint location = attributeNamesCache[attributeName];
 
             Gl.EnableVertexAttribArray(location);
             Gl.BindBuffer(buffer);

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -724,9 +724,7 @@ namespace OpenGL
             where T : struct
         {
             var cachedAttribute = program[attributeName];
-            if(cachedAttribute == null)
-                throw new ArgumentException($"{attributeName} did not exist in the shader.", nameof(attributeName));
-            uint location = (uint)cachedAttribute.Location;
+            uint location = (uint)(cachedAttribute?.Location ?? Gl.GetAttribLocation(program.ProgramID, attributeName));
 
             Gl.EnableVertexAttribArray(location);
             Gl.BindBuffer(buffer);


### PR DESCRIPTION
Gl.GetAttribLocation is an expensive call. It usually gets called multiple times every frame.
I implemented caching in BindBufferToShaderAttribute, so it won't call Gl.GetAttribLocation every time.
The reason why I only do this at GlMethods.BindBufferToShaderAttribute, is because I don't want to modifiy the OpenGL calls in Gl.cs.