### PR TITLE
SDL Key support in Platform.Input

### DIFF
--- a/OpenGL.Platform/Input.cs
+++ b/OpenGL.Platform/Input.cs
@@ -107,9 +107,9 @@ namespace OpenGL.Platform
             // since SDL Keycodes can be 40 or 1073741903
             // map every SDL Keycode to a char starting from 0, incremented by 1
             // for converting to char and easy array indexing
-            sdlKeyMap = new Dictionary<SDL.SDL_Keycode, char>();
+            sdlKeyMap = new Dictionary<SDL.SDL_Scancode, char>();
             char i = (char)0;
-            foreach(SDL.SDL_Keycode keyCode in Enum.GetValues(typeof(SDL.SDL_Keycode)))
+            foreach(SDL.SDL_Scancode keyCode in Enum.GetValues(typeof(SDL.SDL_Scancode)))
             {
                 sdlKeyMap[keyCode] = i++;
             }
@@ -128,7 +128,7 @@ namespace OpenGL.Platform
         private static Click mousePosition, prevMousePosition;         // the current and previous mouse position and button
         private static Event mouseLeft, mouseRight, mouseMiddle;       // the events to be called on a mouse click
         private static Event mouseMove;                                // the event to call on a mouse move event
-        private static Dictionary<SDL.SDL_Keycode, char> sdlKeyMap;    // SDL Keyscodes mapped to a char
+        private static Dictionary<SDL.SDL_Scancode, char> sdlKeyMap;    // SDL Keyscodes mapped to a char
 
         public static bool RightMouse { get; set; }
         public static bool LeftMouse { get; set; }
@@ -263,7 +263,7 @@ namespace OpenGL.Platform
         /// Adds a raw key that has been pressed to the list of keys that are currently held down.
         /// </summary>
         /// <param name="key">The key that was pressed.</param>
-        public static void AddKeyRaw(SDL.SDL_Keycode key)
+        public static void AddKeyRaw(SDL.SDL_Scancode key)
         {
             char keyRaw = sdlKeyMap[key];
             if(KeyBindingsRaw[keyRaw] != null && KeyBindingsRaw[keyRaw].Call != null)    // keybindings performs a lock of subqueue, ensuring thread safety
@@ -310,7 +310,7 @@ namespace OpenGL.Platform
         /// Removes a raw key if a keyup event has been fired.  Stops repeatable events.
         /// </summary>
         /// <param name="key">The key is no longer being pressed.</param>
-        public static void RemoveKeyRaw(SDL.SDL_Keycode key)
+        public static void RemoveKeyRaw(SDL.SDL_Scancode key)
         {
             char keyRaw = sdlKeyMap[key];
             // call a keyup if a key event is registered
@@ -378,7 +378,7 @@ namespace OpenGL.Platform
         /// <summary>
         /// Subscribe an event to an sdl keycode (specified by the char occupying that key).
         /// </summary>
-        public static void SubscribeRaw(SDL.SDL_Keycode Key, Event Event)
+        public static void SubscribeRaw(SDL.SDL_Scancode Key, Event Event)
         {
             char keyRaw = sdlKeyMap[Key];
             KeyBindingsRaw[keyRaw] = Event;
@@ -395,7 +395,7 @@ namespace OpenGL.Platform
         /// <summary>
         /// Subscribe an action to an sdl keycode (specified by the char occupying that key).
         /// </summary>
-        public static void SubscribeRaw(SDL.SDL_Keycode Key, Action Event)
+        public static void SubscribeRaw(SDL.SDL_Scancode Key, Action Event)
         {
             char normalizedKey = sdlKeyMap[Key];
             KeyBindingsRaw[normalizedKey] = new Event(Event);
@@ -415,7 +415,7 @@ namespace OpenGL.Platform
         /// </summary>
         public static void SubscribeAllRaw(Event Event)
         {
-            foreach(SDL.SDL_Keycode key in sdlKeyMap.Keys)
+            foreach(SDL.SDL_Scancode key in sdlKeyMap.Keys)
                 SubscribeRaw(key, Event);
         }
 

--- a/OpenGL.Platform/Input.cs
+++ b/OpenGL.Platform/Input.cs
@@ -131,7 +131,6 @@ namespace OpenGL.Platform
         private static Click mousePosition, prevMousePosition;                  // the current and previous mouse position and button
         private static Event mouseLeft, mouseRight, mouseMiddle;                // the events to be called on a mouse click
         private static Event mouseMove;                                         // the event to call on a mouse move event
-        private static Dictionary<SDL.SDL_Scancode, char> sdlKeyMap;            // SDL Keyscodes mapped to a char
 
         public static bool RightMouse { get; set; }
         public static bool LeftMouse { get; set; }
@@ -411,7 +410,7 @@ namespace OpenGL.Platform
         /// </summary>
         public static void SubscribeAllRaw(Event Event)
         {
-            foreach(SDL.SDL_Scancode key in sdlKeyMap.Keys)
+            foreach(SDL.SDL_Scancode key in Enum.GetValues(typeof(SDL.SDL_Scancode)))
                 SubscribeRaw(key, Event);
         }
 

--- a/OpenGL.Platform/Input.cs
+++ b/OpenGL.Platform/Input.cs
@@ -252,10 +252,8 @@ namespace OpenGL.Platform
                     case '/': mkey = '?'; break;
                 }
             }
-            if (KeyBindings[mkey] != null && KeyBindings[mkey].Call != null)    // keybindings performs a lock of subqueue, ensuring thread safety
-            {
-                KeyBindings[mkey].Call(mkey, true);     // event is called immediately
-            }
+            Event keyBinding = KeyBindings[mkey];
+            keyBinding?.Call?.Invoke(mkey, true);
             lock (keys) if (!keys.Contains(mkey)) keys.Add(mkey);
         }
 
@@ -266,10 +264,8 @@ namespace OpenGL.Platform
         public static void AddKeyRaw(SDL.SDL_Scancode key)
         {
             char keyRaw = sdlKeyMap[key];
-            if(KeyBindingsRaw[keyRaw] != null && KeyBindingsRaw[keyRaw].Call != null)    // keybindings performs a lock of subqueue, ensuring thread safety
-            {
-                KeyBindingsRaw[keyRaw].Call(keyRaw, true);     // event is called immediately
-            }
+            Event keyBinding = KeyBindingsRaw[keyRaw];
+            keyBinding?.Call?.Invoke(keyRaw, true);
             lock(keysRaw)
                 if(!keysRaw.Contains(keyRaw))
                     keysRaw.Add(keyRaw);
@@ -452,16 +448,22 @@ namespace OpenGL.Platform
             // Update all of the event which are repeatable
             lock (keys)
             {
+                Event[] bindings= KeyBindings;
                 for (int i = 0; i < keys.Count; i++)
-                    if (KeyBindings[keys[i]] != null && KeyBindings[keys[i]].Repeat != null)
-                        KeyBindings[keys[i]].Repeat(Time.DeltaTime);
+                {
+                    Event binding = bindings[keys[i]];
+                    binding?.Repeat?.Invoke(Time.DeltaTime);
+                }
             }
 
             lock(keysRaw)
             {
+                Event[] bindings = KeyBindingsRaw;
                 for(int i = 0; i < keysRaw.Count; i++)
-                    if(KeyBindingsRaw[keysRaw[i]] != null && KeyBindingsRaw[keysRaw[i]].Repeat != null)
-                        KeyBindingsRaw[keysRaw[i]].Repeat(Time.DeltaTime);
+                {
+                    Event binding = bindings[keysRaw[i]];
+                    binding?.Repeat?.Invoke(Time.DeltaTime);
+                }
             }
         }
         #endregion

--- a/OpenGL.Platform/Input.cs
+++ b/OpenGL.Platform/Input.cs
@@ -217,7 +217,7 @@ namespace OpenGL.Platform
         public static void AddKey(char key, bool shift, bool ctrl, bool alt)
         {
             char mkey = (char)(key & 0x3f);             // snap the key under 64 so we don't accidentally trigger an alt/ctrl event
-                        if (key > 63)                               // if >63 then it is a letter, apply ctrl+alt+shift
+            if (key > 63)                               // if >63 then it is a letter, apply ctrl+alt+shift
             {
                 mkey = (char)((mkey & 0x1f) |           // first keep only the information relevant to the character
                     ((shift ? 0x00 : 0x20) |            // apply uppercase modifier
@@ -279,7 +279,7 @@ namespace OpenGL.Platform
         /// Removes a key if a keyup event has been fired.  Stops repeatable events.
         /// </summary>
         /// <param name="key">The key is no longer being pressed.</param>
-public static void RemoveKey(char key)
+        public static void RemoveKey(char key)
         {
             // call a keyup if a key event is registered
             if (KeyBindings[key] != null && KeyBindings[key].Call != null) KeyBindings[key].Call(key, false);

--- a/OpenGL.Platform/Input.cs
+++ b/OpenGL.Platform/Input.cs
@@ -15,6 +15,9 @@ namespace OpenGL.Platform
         /// <summary>The keyboard event delegate.</summary>
         public delegate void KeyEvent(char c, bool state);
 
+        /// <summary>The raw keyboard event delegate.</summary>
+        public delegate void KeyRawEvent(SDL.SDL_Scancode key, bool state);
+
         /// <summary>A simple keyboard event delegate that only receives a state.</summary>
         public delegate void StateKeyEvent(bool state);
 
@@ -35,6 +38,9 @@ namespace OpenGL.Platform
 
         /// <summary>A keyEvent delegate which can be called by a keyDown or keyUp event.</summary>
         public KeyEvent Call { get; private set; }
+
+        /// <summary>A raw keyEvent delegate which can be called by a keyDown or keyUp event.</summary>
+        public KeyRawEvent CallRaw { get; private set; }
 
         /// <summary>A mouseEvent delegate which can be called by a mouseDown event.</summary>
         public MouseEvent Click { get; private set; }
@@ -71,6 +77,13 @@ namespace OpenGL.Platform
             this.Call = Event;
         }
 
+        /// <summary>Standard constructor for a raw keyboard event.</summary>
+        /// <param name="Event">The Event to call on a keyDown event.</param>
+        public Event(KeyRawEvent Event)
+        {
+            this.CallRaw = Event;
+        }
+
         /// <summary>Standard constructor for a mouse event.</summary>
         /// <param name="Event">The Event to call on a mouseClick event.</param>
         public Event(MouseEvent Event)
@@ -85,7 +98,7 @@ namespace OpenGL.Platform
             this.Move = Event;
         }
 
-        /// <summary>Standard constructor for a mouse mouse event.</summary>
+        /// <summary>Standard constructor for a keyboard repeat event.</summary>
         /// <param name="Event">The Event to call every frame update.</param>
         public Event(RepeatEvent Event)
         {
@@ -265,7 +278,7 @@ namespace OpenGL.Platform
         {
             char keyRaw = sdlKeyMap[key];
             Event keyBinding = KeyBindingsRaw[keyRaw];
-            keyBinding?.Call?.Invoke(keyRaw, true);
+            keyBinding?.CallRaw?.Invoke(key, true);
             lock(keysRaw)
                 if(!keysRaw.Contains(keyRaw))
                     keysRaw.Add(keyRaw);
@@ -311,7 +324,7 @@ namespace OpenGL.Platform
             char keyRaw = sdlKeyMap[key];
             // call a keyup if a key event is registered
             if(KeyBindingsRaw[keyRaw] != null && KeyBindingsRaw[keyRaw].Call != null)
-                KeyBindingsRaw[keyRaw].Call(keyRaw, false);
+                KeyBindingsRaw[keyRaw].CallRaw(key, false);
             keysRaw.Remove(keyRaw);
         }
 

--- a/OpenGL.Platform/Input.cs
+++ b/OpenGL.Platform/Input.cs
@@ -280,7 +280,8 @@ namespace OpenGL.Platform
         public static void RemoveKey(char key)
         {
             // call a keyup if a key event is registered
-            if (KeyBindings[key] != null && KeyBindings[key].Call != null) KeyBindings[key].Call(key, false);
+            Event keyBinding = KeyBindings[key];
+            keyBinding?.Call?.Invoke(key, false);
 
             // For clarity, I've unwrapped the loop that was originally here, since this is important
             // Sometimes the user will release ctrl/shift/alt while still holding the key down
@@ -311,8 +312,8 @@ namespace OpenGL.Platform
         public static void RemoveKeyRaw(SDL.SDL_Scancode key)
         {
             // call a keyup if a key event is registered
-            if(KeyBindingsRaw[key] != null && KeyBindingsRaw[key].Call != null)
-                KeyBindingsRaw[key].CallRaw(key, false);
+            Event keyBinding = KeyBindingsRaw[key];
+            keyBinding?.CallRaw?.Invoke(key, false);
             keysRaw.Remove(key);
         }
 

--- a/OpenGL.Platform/Window.cs
+++ b/OpenGL.Platform/Window.cs
@@ -402,6 +402,7 @@ namespace OpenGL.Platform
             else if (sym == SDL.SDL_Keycode.SDLK_UP) Input.AddKey((char)2, lshift || rshift, lctrl || rctrl, lalt || ralt);
             else if (sym == SDL.SDL_Keycode.SDLK_DOWN) Input.AddKey((char)3, lshift || rshift, lctrl || rctrl, lalt || ralt);
             else Input.AddKey((char)sym, lshift || rshift, lctrl || rctrl, lalt || ralt);
+            Input.AddKeyRaw(sym);
         }
 
         private static void OnKeyboardUp(SDL.SDL_Keycode sym)
@@ -418,6 +419,7 @@ namespace OpenGL.Platform
             else if (sym == SDL.SDL_Keycode.SDLK_UP) Input.RemoveKey((char)2);
             else if (sym == SDL.SDL_Keycode.SDLK_DOWN) Input.RemoveKey((char)3);
             else Input.RemoveKey((char)sym);
+            Input.RemoveKeyRaw(sym);
         }
         #endregion
     }

--- a/OpenGL.Platform/Window.cs
+++ b/OpenGL.Platform/Window.cs
@@ -192,10 +192,10 @@ namespace OpenGL.Platform
                 switch (sdlEvent.type)
                 {
                     case SDL.SDL_EventType.SDL_KEYDOWN:
-                        OnKeyboardDown(sdlEvent.key.keysym.sym);
+                        OnKeyboardDown(sdlEvent.key.keysym);
                         break;
                     case SDL.SDL_EventType.SDL_KEYUP:
-                        OnKeyboardUp(sdlEvent.key.keysym.sym);
+                        OnKeyboardUp(sdlEvent.key.keysym);
                         break;
                     case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
                     case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
@@ -388,8 +388,9 @@ namespace OpenGL.Platform
         private static bool lshift, lctrl, lalt;
         private static bool rshift, rctrl, ralt;
 
-        private static void OnKeyboardDown(SDL.SDL_Keycode sym)
+        private static void OnKeyboardDown(SDL.SDL_Keysym keysym)
         {
+            SDL.SDL_Keycode sym = keysym.sym;
             // send all keyboard events to the Input static class
             if (sym == SDL.SDL_Keycode.SDLK_LSHIFT) lshift = true;
             else if (sym == SDL.SDL_Keycode.SDLK_RSHIFT) rshift = true;
@@ -402,11 +403,12 @@ namespace OpenGL.Platform
             else if (sym == SDL.SDL_Keycode.SDLK_UP) Input.AddKey((char)2, lshift || rshift, lctrl || rctrl, lalt || ralt);
             else if (sym == SDL.SDL_Keycode.SDLK_DOWN) Input.AddKey((char)3, lshift || rshift, lctrl || rctrl, lalt || ralt);
             else Input.AddKey((char)sym, lshift || rshift, lctrl || rctrl, lalt || ralt);
-            Input.AddKeyRaw(sym);
+            Input.AddKeyRaw(keysym.scancode);
         }
 
-        private static void OnKeyboardUp(SDL.SDL_Keycode sym)
+        private static void OnKeyboardUp(SDL.SDL_Keysym keysym)
         {
+            SDL.SDL_Keycode sym = keysym.sym;
             // send all keyboard events to the Input static class
             if (sym == SDL.SDL_Keycode.SDLK_LSHIFT) lshift = false;
             else if (sym == SDL.SDL_Keycode.SDLK_RSHIFT) rshift = false;
@@ -419,7 +421,7 @@ namespace OpenGL.Platform
             else if (sym == SDL.SDL_Keycode.SDLK_UP) Input.RemoveKey((char)2);
             else if (sym == SDL.SDL_Keycode.SDLK_DOWN) Input.RemoveKey((char)3);
             else Input.RemoveKey((char)sym);
-            Input.RemoveKeyRaw(sym);
+            Input.RemoveKeyRaw(keysym.scancode);
         }
         #endregion
     }

--- a/OpenGL/Constructs/VAO.cs
+++ b/OpenGL/Constructs/VAO.cs
@@ -660,14 +660,6 @@ namespace OpenGL
             BindAttributes(program);
             Gl.DrawElements(DrawMode, VertexCount, elementType, offsetInBytes);
         }
-
-        /// <summary>
-        /// Performs the draw routine with the default shader program.
-        /// </summary>
-        public void DrawProgram()
-        {
-            DrawProgram(Program);
-        }
         #endregion
 
         #region IDisposable

--- a/OpenGL/Constructs/VAO.cs
+++ b/OpenGL/Constructs/VAO.cs
@@ -660,6 +660,14 @@ namespace OpenGL
             BindAttributes(program);
             Gl.DrawElements(DrawMode, VertexCount, elementType, offsetInBytes);
         }
+
+        /// <summary>
+        /// Performs the draw routine with the default shader program.
+        /// </summary>
+        public void DrawProgram()
+        {
+            DrawProgram(Program);
+        }
         #endregion
 
         #region IDisposable


### PR DESCRIPTION
It's possible to subscribe a key event to any key. Including special keys like shift, control and alt. It's very similar to the old names, you just add a **Raw** at the end of the method name and use `SDL.SDL_Keycode` instead of `char` as parameter.

This solves the issue https://github.com/giawa/opengl4csharp/issues/41