### PR TITLE
Fix TakeMin and TakeMax

### DIFF
--- a/OpenGL/Math/Vector3.cs
+++ b/OpenGL/Math/Vector3.cs
@@ -648,7 +648,7 @@ namespace OpenGL
         /// </summary>
         /// <param name="tv">The Vector3 to perform the TakeMin on.</param>
         /// <param name="v">Vector to check against.</param>
-        public static void TakeMin(this Vector3 tv, Vector3 v)
+        public static void TakeMin(this ref Vector3 tv, Vector3 v)
         {
             if (v.X < tv.X) tv.X = v.X;
             if (v.Y < tv.Y) tv.Y = v.Y;
@@ -660,7 +660,7 @@ namespace OpenGL
         /// </summary>
         /// <param name="tv">The Vector3 to perform the TakeMax on.</param>
         /// <param name="v">Vector to check against.</param>
-        public static void TakeMax(this Vector3 tv, Vector3 v)
+        public static void TakeMax(this ref Vector3 tv, Vector3 v)
         {
             if (v.X > tv.X) tv.X = v.X;
             if (v.Y > tv.Y) tv.Y = v.Y;

--- a/OpenGLUnitTests/Vector3Tests.cs
+++ b/OpenGLUnitTests/Vector3Tests.cs
@@ -5,9 +5,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #if USE_NUMERICS
 using System.Numerics;
-#else
-using OpenGL;
 #endif
+using OpenGL;
 
 namespace OpenGLUnitTests
 {
@@ -22,6 +21,32 @@ namespace OpenGLUnitTests
             Assert.AreEqual(Vector3.UnitY, new Vector3(0, 1, 0));
             Assert.AreEqual(Vector3.UnitZ, new Vector3(0, 0, 1));
             Assert.AreEqual(Vector3.Zero, new Vector3(0, 0, 0));
+        }
+
+        [TestMethod]
+        public void Vector3TakeMin()
+        {
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                Vector3 v1 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
+                Vector3 v2 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
+                Vector3 a = v1;
+                a.TakeMin(v2);
+                Assert.AreEqual(a, new Vector3(Math.Min(v1.X, v2.X), Math.Min(v1.Y, v2.Y), Math.Min(v1.Z, v2.Z)));
+            }
+        }
+
+        [TestMethod]
+        public void Vector3TakeMax()
+        {
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                Vector3 v1 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
+                Vector3 v2 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
+                Vector3 a = v1;
+                a.TakeMax(v2);
+                Assert.AreEqual(a, new Vector3(Math.Max(v1.X, v2.X), Math.Max(v1.Y, v2.Y), Math.Max(v1.Z, v2.Z)));
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
Vector3.TakeMin/TakeMax didn't work when using `System.numerics` because the extension methods only worked on a copy of the vector. Fixed by taking a reference to the vector instead of a copy.