### PR TITLE
Make it possible to make a VBO without also allocating an array

### DIFF
--- a/OpenGL/Constructs/VBO.cs
+++ b/OpenGL/Constructs/VBO.cs
@@ -207,6 +207,22 @@ namespace OpenGL
         }
 
         /// <summary>
+        /// Creates a buffer object of type T with a specified length.
+        /// </summary>
+        /// <param name="Length">The length of the vertex buffer.</param>
+        /// <param name="Target">Specifies the target buffer object.</param>
+        /// <param name="Hint">Specifies the expected usage of the data store.</param>
+        public VBO(int Length, BufferTarget Target = BufferTarget.ArrayBuffer, BufferUsageHint Hint = BufferUsageHint.StaticDraw)
+        {
+            ID = Gl.CreateVBO<T>(BufferTarget = Target, Hint, Length);
+
+            this.Size = GetTypeComponentSize();
+            this.PointerType = GetAttribPointerType();
+            this.Count = Length;
+            this.IsIntegralType = IsTypeIntegral();
+        }
+
+        /// <summary>
         /// Get the component size of T.
         /// </summary>
         /// <returns>The component size of T.</returns>

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -381,6 +381,19 @@ namespace OpenGL
         }
 
         /// <summary>
+        /// Creates and initializes an empty buffer object's data store.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="target">Specifies the target buffer object.</param>
+        /// <param name="size">Specifies the size in bytes of the buffer object's new data store.</param>
+        /// <param name="usage">Specifies expected usage pattern of the data store.</param>
+        public static void BufferData<T>(BufferTarget target, Int32 size, BufferUsageHint usage)
+            where T : struct
+        {
+            Delegates.glBufferData(target, new IntPtr(size), IntPtr.Zero, usage);
+        }
+
+        /// <summary>
         /// Creates and initializes a buffer object's data store.
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -481,6 +494,32 @@ namespace OpenGL
 
             Gl.BindBuffer(target, vboHandle);
             Gl.BufferData<T>(target, offset, size, data, hint);
+            Gl.BindBuffer(target, 0);
+            return vboHandle;
+        }
+
+        /// <summary>
+        /// Creates a standard VBO of type T with a specified length.
+        /// </summary>
+        /// <typeparam name="T">The type of the data being stored in the VBO (make sure it's byte aligned).</typeparam>
+        /// <param name="target">The VBO BufferTarget (usually ArrayBuffer or ElementArrayBuffer).</param>
+        /// <param name="hint">The buffer usage hint (usually StaticDraw).</param>
+        /// <param name="length">The length of the VBO.</param>
+        /// <returns>The buffer ID of the VBO on success, 0 on failure.</returns>
+        public static uint CreateVBO<T>(BufferTarget target, BufferUsageHint hint, int length)
+            where T : struct
+        {
+            uint vboHandle = Gl.GenBuffer();
+            if (vboHandle == 0) return 0;
+
+            int size = length * Marshal.SizeOf<T>();
+
+#if MEMORY_LOGGER
+            MemoryLogger.AllocateVBO(vboHandle, size);
+#endif
+
+            Gl.BindBuffer(target, vboHandle);
+            Gl.BufferData<T>(target, size, hint);
             Gl.BindBuffer(target, 0);
             return vboHandle;
         }

--- a/OpenGL/Math/Vector3.cs
+++ b/OpenGL/Math/Vector3.cs
@@ -648,7 +648,7 @@ namespace OpenGL
         /// </summary>
         /// <param name="tv">The Vector3 to perform the TakeMin on.</param>
         /// <param name="v">Vector to check against.</param>
-        public static void TakeMin(this Vector3 tv, Vector3 v)
+        public static void TakeMin(this ref Vector3 tv, Vector3 v)
         {
             if (v.X < tv.X) tv.X = v.X;
             if (v.Y < tv.Y) tv.Y = v.Y;
@@ -660,7 +660,7 @@ namespace OpenGL
         /// </summary>
         /// <param name="tv">The Vector3 to perform the TakeMax on.</param>
         /// <param name="v">Vector to check against.</param>
-        public static void TakeMax(this Vector3 tv, Vector3 v)
+        public static void TakeMax(this ref Vector3 tv, Vector3 v)
         {
             if (v.X > tv.X) tv.X = v.X;
             if (v.Y > tv.Y) tv.Y = v.Y;

--- a/OpenGLUnitTests/Vector3Tests.cs
+++ b/OpenGLUnitTests/Vector3Tests.cs
@@ -5,9 +5,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #if USE_NUMERICS
 using System.Numerics;
-#else
-using OpenGL;
 #endif
+using OpenGL;
 
 namespace OpenGLUnitTests
 {
@@ -22,6 +21,32 @@ namespace OpenGLUnitTests
             Assert.AreEqual(Vector3.UnitY, new Vector3(0, 1, 0));
             Assert.AreEqual(Vector3.UnitZ, new Vector3(0, 0, 1));
             Assert.AreEqual(Vector3.Zero, new Vector3(0, 0, 0));
+        }
+
+        [TestMethod]
+        public void Vector3TakeMin()
+        {
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                Vector3 v1 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
+                Vector3 v2 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
+                Vector3 a = v1;
+                a.TakeMin(v2);
+                Assert.AreEqual(a, new Vector3(Math.Min(v1.X, v2.X), Math.Min(v1.Y, v2.Y), Math.Min(v1.Z, v2.Z)));
+            }
+        }
+
+        [TestMethod]
+        public void Vector3TakeMax()
+        {
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                Vector3 v1 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
+                Vector3 v2 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
+                Vector3 a = v1;
+                a.TakeMax(v2);
+                Assert.AreEqual(a, new Vector3(Math.Max(v1.X, v2.X), Math.Max(v1.Y, v2.Y), Math.Max(v1.Z, v2.Z)));
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
Made a `VBO` constructor that doesn't require an array of data to be avilable.

Before you had to do this:
`VBO<Vector3> vertices = new VBO<Vector3>(new Vector3[1000]);`

Essentially create an array just to create a VBO.
This Pr makes it possible to do this:
`VBO<Vector3> vertices = new VBO<Vector3>(1000);`

Makes a `VBO` of the same size, but without allocating an array for it.