### PR TITLE
VAO method to draw with glMultiDrawElementsIndirect 

### DIFF
--- a/OpenGL/Constructs/DrawElementsIndirectCommand.cs
+++ b/OpenGL/Constructs/DrawElementsIndirectCommand.cs
@@ -1,0 +1,42 @@
+﻿using System.Runtime.InteropServices;
+
+namespace OpenGL.Constructs
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly struct DrawElementsIndirectCommand
+    {
+        /// <summary>
+        /// Element count
+        /// </summary>
+        private readonly uint Count;
+
+        /// <summary>
+        /// Instance count
+        /// </summary>
+        private readonly uint InstanceCount;
+
+        /// <summary>
+        /// Index of first element in base array
+        /// </summary>
+        private readonly uint FirstIndex;
+
+        /// <summary>
+        /// Index of first vertex in base array
+        /// </summary>
+        private readonly uint BaseVertex;
+
+        /// <summary>
+        /// Index of the first instance in base array
+        /// </summary>
+        private readonly uint BaseInstance;
+
+        public DrawElementsIndirectCommand(int elementCount, int instanceCount, int firstElementIndex, int firstVertexIndex, int firstInstanceIndex)
+        {
+            this.Count = (uint)elementCount;
+            this.InstanceCount = (uint)instanceCount;
+            this.FirstIndex = (uint)firstElementIndex;
+            this.BaseVertex = (uint)firstVertexIndex;
+            this.BaseInstance = (uint)firstInstanceIndex;
+        }
+    }
+}

--- a/OpenGL/Constructs/VAO.cs
+++ b/OpenGL/Constructs/VAO.cs
@@ -434,7 +434,7 @@ namespace OpenGL
                 Draw = DrawOGL3;
                 DrawInstanced = DrawInstancedOGL3;
 
-                if (Gl.Version() >= 4 && Gl.VersionMinor() >= 3)
+                if (Gl.Version() > 4 || (Gl.Version() == 4 && Gl.VersionMinor() >= 3))
                 {
                     MultiDrawElementsIndirect = MultiDrawElementsIndirectOGL43;
                 }

--- a/OpenGL/Constructs/VBO.cs
+++ b/OpenGL/Constructs/VBO.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
+using OpenGL.Constructs;
 
 #if USE_NUMERICS
 using System.Numerics;
@@ -28,6 +29,7 @@ namespace OpenGL
             [typeof(Vector2)] = 2,
             [typeof(Vector3)] = 3,
             [typeof(Vector4)] = 4,
+            [typeof(DrawElementsIndirectCommand)] = 1,
             //[typeof(int2101010)] = 4,
             //[typeof(uint2101010)] = 4,
             //[typeof(uint10f11f11f)] = 3,
@@ -49,6 +51,7 @@ namespace OpenGL
             [typeof(Vector2)] = VertexAttribPointerType.Float,
             [typeof(Vector3)] = VertexAttribPointerType.Float,
             [typeof(Vector4)] = VertexAttribPointerType.Float,
+            [typeof(DrawElementsIndirectCommand)] = VertexAttribPointerType.Byte
             //[typeof(int2101010)] = VertexAttribPointerType.UnsignedInt2101010Reversed,
             //[typeof(uint2101010)] = VertexAttribPointerType.UnsignedUInt2101010Reversed,
             //[typeof(uint10f11f11f)] = VertexAttribPointerType.UnsignedUInt101111Reversed
@@ -276,7 +279,8 @@ namespace OpenGL
         public void BufferSubData(T[] data, int size, int offset)
         {
             if (BufferTarget != BufferTarget.ArrayBuffer && BufferTarget != BufferTarget.ElementArrayBuffer &&
-                BufferTarget != BufferTarget.PixelPackBuffer && BufferTarget != BufferTarget.PixelUnpackBuffer)
+                BufferTarget != BufferTarget.PixelPackBuffer && BufferTarget != BufferTarget.PixelUnpackBuffer &&
+                BufferTarget != BufferTarget.DrawIndirectBuffer)
                 throw new InvalidOperationException(string.Format("BufferSubData cannot be called with a BufferTarget of type {0}", BufferTarget.ToString()));
 
             GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);

--- a/OpenGL/Core/GlMethods.cs
+++ b/OpenGL/Core/GlMethods.cs
@@ -107,6 +107,7 @@ namespace OpenGL
 
         #region Private Fields
         private static int version = 0;
+        private static int versionMinor = 0;
         private static uint currentProgram = 0;
         #endregion
 
@@ -691,9 +692,9 @@ namespace OpenGL
         }
 
         /// <summary>
-        /// Gets the current OpenGL version (returns a cached result on subsequent calls).
+        /// Gets the current major OpenGL version (returns a cached result on subsequent calls).
         /// </summary>
-        /// <returns>The current OpenGL version, or 0 on an error.</returns>
+        /// <returns>The current major OpenGL version, or 0 on an error.</returns>
         public static int Version()
         {
             if (version != 0) return version; // cache the version information
@@ -709,6 +710,28 @@ namespace OpenGL
             {
                 //Console.WriteLine("Error while retrieving the OpenGL version.");
                 return 0;
+            }
+        }
+
+        /// <summary>
+        /// Gets the current minor OpenGL version (returns a cached result on subsequent calls).
+        /// </summary>
+        /// <returns>The current minor OpenGL version, or -1 on an error.</returns>
+        public static int VersionMinor()
+        {
+            if (versionMinor != 0) return versionMinor; // cache the version information
+
+            try
+            {
+                string versionString = Gl.GetString(StringName.Version);
+
+                versionMinor = int.Parse(versionString.Split('.')[1]);
+                return Gl.versionMinor;
+            }
+            catch (Exception)
+            {
+                //Console.WriteLine("Error while retrieving the OpenGL version.");
+                return -1;
             }
         }
 


### PR DESCRIPTION
[glMultiDrawElementsIndirect](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMultiDrawElementsIndirect.xhtml) can execute multiple draw commands at once from a `VBO` of commands. 

This PR adds the draw command struct `DrawElementsIndirectCommand`. `VBO` had to support the new struct and i an not sure i did it in the best way.  I just gave it a random `VertexAttribPointerType` but maybe it should be special cased to a new `VertexAttribPointerType.Invalid`?.

`glMultiDrawElementsIndirect` is only supported in OpenGL 4.3, so i added a new method to get the minor OpenGL version number. If OpenGL 4.3 isn't supported then the draw method throws an exception.
The new draw command itself takes a `VBO` of commands so it's possible to swap command buffers between calls if one wishes to do so.

