### PR TITLE
Span and allocation free overloads for Geometry.CalculateNormals

### DIFF
--- a/OpenGL/Constructs/Geometry.cs
+++ b/OpenGL/Constructs/Geometry.cs
@@ -61,11 +61,11 @@ namespace OpenGL
         {
             if ((elementData.Length % 3) != 0)
             {
-                throw new ArgumentOutOfRangeException($"Expected {nameof(elementData)} to be a multiple of 3 as each triangle consists of 3 points.");
+                throw new ArgumentException($"Expected {nameof(elementData)} to be a multiple of 3 as each triangle consists of 3 points.", nameof(elementData));
             }
             if (vertexData.Length != normalData.Length)
             {
-                throw new ArgumentOutOfRangeException($"Expected {nameof(vertexData)} and {nameof(normalData)} to have the same length.");
+                throw new ArgumentException($"Expected {nameof(vertexData)} and {nameof(normalData)} to have the same length.", nameof(vertexData));
             }
 
             for (int i = 0; i < elementData.Length; i += 3)

--- a/OpenGL/Constructs/Geometry.cs
+++ b/OpenGL/Constructs/Geometry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 #if USE_NUMERICS
 using System.Numerics;
 #endif
@@ -20,28 +21,8 @@ namespace OpenGL
         [Obsolete("Use uint[] instead of int[].")]
         public static Vector3[] CalculateNormals(Vector3[] vertexData, int[] elementData)
         {
-            Vector3 b1, b2, normal;
-            Vector3[] normalData = new Vector3[vertexData.Length];
-
-            for (int i = 0; i < elementData.Length / 3; i++)
-            {
-                int cornerA = elementData[i * 3];
-                int cornerB = elementData[i * 3 + 1];
-                int cornerC = elementData[i * 3 + 2];
-
-                b1 = vertexData[cornerB] - vertexData[cornerA];
-                b2 = vertexData[cornerC] - vertexData[cornerA];
-
-                normal = Vector3.Cross(b1, b2).Normalize();
-
-                normalData[cornerA] += normal;
-                normalData[cornerB] += normal;
-                normalData[cornerC] += normal;
-            }
-
-            for (int i = 0; i < normalData.Length; i++) normalData[i] = normalData[i].Normalize();
-
-            return normalData;
+            Span<uint> uintElementData = MemoryMarshal.Cast<int, uint>(elementData);
+            return CalculateNormals(vertexData.AsSpan(), uintElementData);
         }
 
         /// <summary>
@@ -52,28 +33,62 @@ namespace OpenGL
         /// <returns></returns>
         public static Vector3[] CalculateNormals(Vector3[] vertexData, uint[] elementData)
         {
-            Vector3 b1, b2, normal;
+            return CalculateNormals(vertexData.AsSpan(), elementData.AsSpan());
+        }
+
+        /// <summary>
+        /// Calculate the array of vertex normals based on vertex and face information (assuming triangle polygons).
+        /// </summary>
+        /// <param name="vertexData">The vertex data to find the normals for.</param>
+        /// <param name="elementData">The element array describing the order in which vertices are drawn.</param>
+        /// <returns></returns>
+        public static Vector3[] CalculateNormals(Span<Vector3> vertexData, Span<uint> elementData)
+        {
             Vector3[] normalData = new Vector3[vertexData.Length];
+            CalculateNormals(vertexData, elementData, normalData);
+            return normalData;
+        }
 
-            for (int i = 0; i < elementData.Length / 3; i++)
+        /// <summary>
+        /// Calculate the array of vertex normals based on vertex and face information (assuming triangle polygons)
+        /// and put the normals into the provided array.
+        /// </summary>
+        /// <param name="vertexData">The vertex data to find the normals for.</param>
+        /// <param name="elementData">The element array describing the order in which vertices are drawn.</param>
+        /// <param name="normalData">The array the normals will be put into. Has to be the same length as the vertex array</param>
+        /// <returns></returns>
+        public static void CalculateNormals(Span<Vector3> vertexData, Span<uint> elementData, Span<Vector3> normalData)
+        {
+            if ((elementData.Length % 3) != 0)
             {
-                uint cornerA = elementData[i * 3];
-                uint cornerB = elementData[i * 3 + 1];
-                uint cornerC = elementData[i * 3 + 2];
+                throw new ArgumentOutOfRangeException($"Expected {nameof(elementData)} to be a multiple of 3 as each triangle consists of 3 points.");
+            }
+            if (vertexData.Length != normalData.Length)
+            {
+                throw new ArgumentOutOfRangeException($"Expected {nameof(vertexData)} and {nameof(normalData)} to have the same length.");
+            }
 
-                b1 = vertexData[cornerB] - vertexData[cornerA];
-                b2 = vertexData[cornerC] - vertexData[cornerA];
+            for (int i = 0; i < elementData.Length; i += 3)
+            {
+                int cornerAIndex = (int)elementData[i + 0];
+                int cornerBIndex = (int)elementData[i + 1];
+                int cornerCIndex = (int)elementData[i + 2];
 
-                normal = Vector3.Cross(b1, b2).Normalize();
+                Vector3 cornerA = vertexData[cornerAIndex];
+                Vector3 cornerB = vertexData[cornerBIndex];
+                Vector3 cornerC = vertexData[cornerCIndex];
 
-                normalData[cornerA] += normal;
-                normalData[cornerB] += normal;
-                normalData[cornerC] += normal;
+                Vector3 ab = cornerB - cornerA;
+                Vector3 ac = cornerC - cornerA;
+
+                Vector3 normal = Vector3.Cross(ab, ac).Normalize();
+
+                normalData[cornerAIndex] += normal;
+                normalData[cornerBIndex] += normal;
+                normalData[cornerCIndex] += normal;
             }
 
             for (int i = 0; i < normalData.Length; i++) normalData[i] = normalData[i].Normalize();
-
-            return normalData;
         }
 
         /// <summary>

--- a/OpenGL/Constructs/Geometry.cs
+++ b/OpenGL/Constructs/Geometry.cs
@@ -17,7 +17,7 @@ namespace OpenGL
         /// </summary>
         /// <param name="vertexData">The vertex data to find the normals for.</param>
         /// <param name="elementData">The element array describing the order in which vertices are drawn.</param>
-        /// <returns></returns>
+        /// <returns>An array with the vertex normals.</returns>
         [Obsolete("Use uint[] instead of int[].")]
         public static Vector3[] CalculateNormals(Vector3[] vertexData, int[] elementData)
         {
@@ -30,7 +30,7 @@ namespace OpenGL
         /// </summary>
         /// <param name="vertexData">The vertex data to find the normals for.</param>
         /// <param name="elementData">The element array describing the order in which vertices are drawn.</param>
-        /// <returns></returns>
+        /// <returns>An array with the vertex normals.</returns>
         public static Vector3[] CalculateNormals(Vector3[] vertexData, uint[] elementData)
         {
             return CalculateNormals(vertexData.AsSpan(), elementData.AsSpan());
@@ -41,7 +41,7 @@ namespace OpenGL
         /// </summary>
         /// <param name="vertexData">The vertex data to find the normals for.</param>
         /// <param name="elementData">The element array describing the order in which vertices are drawn.</param>
-        /// <returns></returns>
+        /// <returns>An array with the vertex normals.</returns>
         public static Vector3[] CalculateNormals(ReadOnlySpan<Vector3> vertexData, ReadOnlySpan<uint> elementData)
         {
             Vector3[] normalData = new Vector3[vertexData.Length];
@@ -56,7 +56,6 @@ namespace OpenGL
         /// <param name="vertexData">The vertex data to find the normals for.</param>
         /// <param name="elementData">The element array describing the order in which vertices are drawn.</param>
         /// <param name="normalData">The array the normals will be put into. Has to be the same length as the vertex array</param>
-        /// <returns></returns>
         public static void CalculateNormals(ReadOnlySpan<Vector3> vertexData, ReadOnlySpan<uint> elementData, Span<Vector3> normalData)
         {
             if ((elementData.Length % 3) != 0)

--- a/OpenGL/Constructs/Geometry.cs
+++ b/OpenGL/Constructs/Geometry.cs
@@ -42,7 +42,7 @@ namespace OpenGL
         /// <param name="vertexData">The vertex data to find the normals for.</param>
         /// <param name="elementData">The element array describing the order in which vertices are drawn.</param>
         /// <returns></returns>
-        public static Vector3[] CalculateNormals(Span<Vector3> vertexData, Span<uint> elementData)
+        public static Vector3[] CalculateNormals(ReadOnlySpan<Vector3> vertexData, ReadOnlySpan<uint> elementData)
         {
             Vector3[] normalData = new Vector3[vertexData.Length];
             CalculateNormals(vertexData, elementData, normalData);
@@ -57,7 +57,7 @@ namespace OpenGL
         /// <param name="elementData">The element array describing the order in which vertices are drawn.</param>
         /// <param name="normalData">The array the normals will be put into. Has to be the same length as the vertex array</param>
         /// <returns></returns>
-        public static void CalculateNormals(Span<Vector3> vertexData, Span<uint> elementData, Span<Vector3> normalData)
+        public static void CalculateNormals(ReadOnlySpan<Vector3> vertexData, ReadOnlySpan<uint> elementData, Span<Vector3> normalData)
         {
             if ((elementData.Length % 3) != 0)
             {

--- a/OpenGL/OpenGL.csproj
+++ b/OpenGL/OpenGL.csproj
@@ -18,9 +18,10 @@
   <ItemGroup>
     <Content Include="lib\ImageSharp.dll"></Content>
     <Content Include="OpenGL.dll.config"></Content>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.3.0"></PackageReference>
-    <PackageReference Include="System.Buffers" Version="4.3.0"></PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.3.0"></PackageReference>
+    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0"></PackageReference>
+    <PackageReference Include="System.Buffers" Version="4.5.1"></PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3"></PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.4"></PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenGLUnitTests/GeometryTests.cs
+++ b/OpenGLUnitTests/GeometryTests.cs
@@ -1,0 +1,139 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenGL;
+using System;
+using System.Buffers;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace OpenGLUnitTests
+{
+    [TestClass]
+    public class GeometryTests
+    {
+        [TestMethod]
+        public void CalculateNormalsSingleTriangle()
+        {
+            Vector3[] vertices = new Vector3[]
+            {
+                new Vector3(0, 1, 0),
+                new Vector3(1, 0, 0),
+                new Vector3(0, 0, 0)
+            };
+            uint[] elements = new uint[] { 0, 1, 2 };
+
+            Vector3[] expectedNormals = new Vector3[]
+            {
+                new Vector3(0, 0, -1),
+                new Vector3(0, 0, -1),
+                new Vector3(0, 0, -1)
+            };
+
+            VerifyOverloads(vertices, elements, expectedNormals);
+        }
+
+        [TestMethod]
+        public void CalculateNormalsSingleTriangleReversed()
+        {
+            Vector3[] vertices = new Vector3[]
+            {
+                new Vector3(0, 1, 0),
+                new Vector3(1, 0, 0),
+                new Vector3(0, 0, 0)
+            };
+            uint[] elements = new uint[] { 2, 1, 0 };
+
+            Vector3[] expectedNormals = new Vector3[]
+            {
+                new Vector3(0, 0, 1),
+                new Vector3(0, 0, 1),
+                new Vector3(0, 0, 1)
+            };
+
+            VerifyOverloads(vertices, elements, expectedNormals);
+        }
+
+        [TestMethod]
+        public void CalculateNormalsMultipleTriangles()
+        {
+            // Pyramid shape
+            Vector3[] vertices = new Vector3[]
+            {
+                new Vector3( 0, 1,  0),
+                new Vector3( 0, 0,  1),
+                new Vector3( 1, 0,  0),
+                new Vector3( 0, 0, -1),
+                new Vector3(-1, 0,  0)
+            };
+            uint[] elements = new uint[] 
+            { 
+                0, 1, 2,
+                0, 2, 3,
+                0, 3, 4,
+                0, 4, 1
+            };
+
+            Vector3[] expectedNormals = new Vector3[]
+            {
+                new Vector3( 0, 1,  0).Normalize(),
+                new Vector3( 0, 1,  1).Normalize(),
+                new Vector3( 1, 1,  0).Normalize(),
+                new Vector3( 0, 1, -1).Normalize(),
+                new Vector3(-1, 1,  0).Normalize()
+            };
+
+            VerifyOverloads(vertices, elements, expectedNormals);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void CalculateNormalWrongSizeNormalArray()
+        {
+            Geometry.CalculateNormals(new Vector3[3], new uint[3], new Vector3[2]);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void CalculateNormalWrongSizeElementArray()
+        {
+            Geometry.CalculateNormals(new Vector3[3], new uint[4]);
+        }
+
+        private void VerifyOverloads(Vector3[] vertices, uint[] elements, Vector3[] expectedNormals)
+        {
+            {
+                int[] intElements = new int[elements.Length];
+                Span<int> casted = MemoryMarshal.Cast<uint, int>(elements);
+                casted.CopyTo(intElements);
+                Vector3[] actualNormals = Geometry.CalculateNormals(vertices, intElements);
+                CompareNormalArrays(expectedNormals, actualNormals);
+            }
+            {
+                Vector3[] actualNormals = Geometry.CalculateNormals(vertices, elements);
+                CompareNormalArrays(expectedNormals, actualNormals);
+            }
+            {
+                Vector3[] actualNormals = Geometry.CalculateNormals(vertices.AsSpan(), elements.AsSpan());
+                CompareNormalArrays(expectedNormals, actualNormals);
+            }
+            {
+                Vector3[] actualNormals = new Vector3[expectedNormals.Length];
+                Geometry.CalculateNormals(vertices, elements, actualNormals);
+                CompareNormalArrays(expectedNormals, actualNormals);
+            }
+        }
+
+        private void CompareNormalArrays(Vector3[] expected, Vector3[] actual)
+        {
+            Assert.AreEqual(expected.Length, actual.Length, $"{Environment.NewLine}Expected {expected.Length} normals but got {actual.Length} normals.");
+            for (int i = 0; i < expected.Length; i++)
+            {
+                CompareVectors(expected[i], actual[i]);
+            }
+        }
+
+        private void CompareVectors(Vector3 expected, Vector3 actual)
+        {
+            Assert.AreEqual(expected, actual, $"{Environment.NewLine}Expected: {expected}{Environment.NewLine}Actual:   {actual}");
+        }
+    }
+}

--- a/OpenGLUnitTests/GeometryTests.cs
+++ b/OpenGLUnitTests/GeometryTests.cs
@@ -85,14 +85,14 @@ namespace OpenGLUnitTests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [ExpectedException(typeof(ArgumentException))]
         public void CalculateNormalWrongSizeNormalArray()
         {
             Geometry.CalculateNormals(new Vector3[3], new uint[3], new Vector3[2]);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [ExpectedException(typeof(ArgumentException))]
         public void CalculateNormalWrongSizeElementArray()
         {
             Geometry.CalculateNormals(new Vector3[3], new uint[4]);

--- a/OpenGLUnitTests/OpenGLUnitTests.csproj
+++ b/OpenGLUnitTests/OpenGLUnitTests.csproj
@@ -38,10 +38,12 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Numerics.Vectors.4.3.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0"></PackageReference>
+    <PackageReference Include="System.Buffers" Version="4.5.1"></PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3"></PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.4"></PackageReference>
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
@@ -49,6 +51,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GeometryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Matrix4Tests.cs" />
     <Compile Include="Matrix2Tests.cs" />


### PR DESCRIPTION
Added two new overloads to `Geometry.CalculateNormals`

- `CalculateNormals(Span<Vector3> vertexData, Span<uint> elementData)`. Takes spans instead of arrays as inputs. usefull when you only want to make normals from part of you vertices.
- `CalculateNormals(Span<Vector3> vertexData, Span<uint> elementData, Span<Vector3> normalData)`. Same as previous one, except you have to supply your own array that the calculated normals will reside in. Useful when you know you can reuse an array.

´Span´ is part of the nuget package `System.Memory`. `System.Memory` required newer versions of the other packages this project uses so they had to be updated.

There was previously two versions on `CalculateNormals`, one that took an `uint` array of elements and one that took an `int` array. I merged those two into one method. 
Added two checks to the method. First verifies that the element array length is a multiple of three. The second checks whether the supplied normal array is the same length as the vertex array.

Lastly added a few tests to verify the behavior.

