### PR TITLE
Optimizations for Matrix4, BoundingBox and Frustum

### DIFF
--- a/OpenGL/Math/BoundingBox.cs
+++ b/OpenGL/Math/BoundingBox.cs
@@ -48,7 +48,7 @@ namespace OpenGL
         /// </summary>
         public Vector3 Center
         {
-            get { return new Vector3((max.X + min.X) * 0.5f, (max.Y + min.Y) * 0.5f, (max.Z + min.Z) * 0.5f); }
+            get { return (max + min) * 0.5f; }
         }
 
         /// <summary>

--- a/OpenGL/Math/Frustum.cs
+++ b/OpenGL/Math/Frustum.cs
@@ -75,12 +75,14 @@ namespace OpenGL
         /// <returns>True if an intersection exists.</returns>
         public bool Intersects(AxisAlignedBoundingBox box)
         {
+            Vector3 boxCenter = box.Center;
+            Vector3 boxSize = box.Size;
             for (int i = 0; i < 6; i++)
             {
                 Plane p = planes[i];
 
-                float d = box.Center.Dot(p.Normal);
-                float r = box.Size.X * Math.Abs(p.Normal.X) + box.Size.Y * Math.Abs(p.Normal.Y) + box.Size.Z * Math.Abs(p.Normal.Z);
+                float d = boxCenter.Dot(p.Normal);
+                float r = boxSize.Dot(Vector3.Abs(p.Normal));
                 float dpr = d + r;
                 //float dmr = d - r;
 

--- a/OpenGL/Math/Matrix4.cs
+++ b/OpenGL/Math/Matrix4.cs
@@ -32,24 +32,12 @@ namespace OpenGL
 
         public static Matrix4 operator *(Matrix4 m, Matrix4 m2)
         {
-            Matrix4 r = new Matrix4(
-            new Vector4(m[0].X * m2[0].X + m[0].Y * m2[1].X + m[0].Z * m2[2].X + m[0].W * m2[3].X,
-                m[0].X * m2[0].Y + m[0].Y * m2[1].Y + m[0].Z * m2[2].Y + m[0].W * m2[3].Y,
-                m[0].X * m2[0].Z + m[0].Y * m2[1].Z + m[0].Z * m2[2].Z + m[0].W * m2[3].Z,
-                m[0].X * m2[0].W + m[0].Y * m2[1].W + m[0].Z * m2[2].W + m[0].W * m2[3].W),
-            new Vector4(m[1].X * m2[0].X + m[1].Y * m2[1].X + m[1].Z * m2[2].X + m[1].W * m2[3].X,
-                m[1].X * m2[0].Y + m[1].Y * m2[1].Y + m[1].Z * m2[2].Y + m[1].W * m2[3].Y,
-                m[1].X * m2[0].Z + m[1].Y * m2[1].Z + m[1].Z * m2[2].Z + m[1].W * m2[3].Z,
-                m[1].X * m2[0].W + m[1].Y * m2[1].W + m[1].Z * m2[2].W + m[1].W * m2[3].W),
-            new Vector4(m[2].X * m2[0].X + m[2].Y * m2[1].X + m[2].Z * m2[2].X + m[2].W * m2[3].X,
-                m[2].X * m2[0].Y + m[2].Y * m2[1].Y + m[2].Z * m2[2].Y + m[2].W * m2[3].Y,
-                m[2].X * m2[0].Z + m[2].Y * m2[1].Z + m[2].Z * m2[2].Z + m[2].W * m2[3].Z,
-                m[2].X * m2[0].W + m[2].Y * m2[1].W + m[2].Z * m2[2].W + m[2].W * m2[3].W),
-            new Vector4(m[3].X * m2[0].X + m[3].Y * m2[1].X + m[3].Z * m2[2].X + m[3].W * m2[3].X,
-                m[3].X * m2[0].Y + m[3].Y * m2[1].Y + m[3].Z * m2[2].Y + m[3].W * m2[3].Y,
-                m[3].X * m2[0].Z + m[3].Y * m2[1].Z + m[3].Z * m2[2].Z + m[3].W * m2[3].Z,
-                m[3].X * m2[0].W + m[3].Y * m2[1].W + m[3].Z * m2[2].W + m[3].W * m2[3].W));
-            return r;
+            Matrix4 m2t = m2.Transpose();
+            return new Matrix4(
+                m2t * m.row1,
+                m2t * m.row2,
+                m2t * m.row3,
+                m2t * m.row4);
         }
 
         public static Matrix4 operator *(Matrix4 m1, float d)
@@ -64,32 +52,30 @@ namespace OpenGL
 
         public static Vector3 operator *(Matrix4 m1, Vector3 v)
         {
-            return new Vector3(m1[0].X * v.X + m1[0].Y * v.Y + m1[0].Z * v.Z,
-                m1[1].X * v.X + m1[1].Y * v.Y + m1[1].Z * v.Z,
-                m1[2].X * v.X + m1[2].Y * v.Y + m1[2].Z * v.Z);
+            Vector4 v4 = new Vector4(v, 0.0f);
+            return new Vector3(Vector4.Dot(m1.row1, v4), Vector4.Dot(m1.row2, v4), Vector4.Dot(m1.row3, v4));
         }
 
         public static Vector3 operator *(Vector3 v, Matrix4 m1)
         {
-            return new Vector3(v.X * m1[0].X + v.Y * m1[1].X + v.Z * m1[2].X,
+            return new Vector3(
+                v.X * m1[0].X + v.Y * m1[1].X + v.Z * m1[2].X,
                 v.X * m1[0].Y + v.Y * m1[1].Y + v.Z * m1[2].Y,
                 v.X * m1[0].Z + v.Y * m1[1].Z + v.Z * m1[2].Z);
         }
 
         public static Vector4 operator *(Matrix4 m1, Vector4 v)
         {
-            return new Vector4(m1[0].X * v.X + m1[0].Y * v.Y + m1[0].Z * v.Z + m1[0].W * v.W,
-                m1[1].X * v.X + m1[1].Y * v.Y + m1[1].Z * v.Z + m1[1].W * v.W,
-                m1[2].X * v.X + m1[2].Y * v.Y + m1[2].Z * v.Z + m1[2].W * v.W,
-                m1[3].X * v.X + m1[3].Y * v.Y + m1[3].Z * v.Z + m1[3].W * v.W);
+            return new Vector4(
+                Vector4.Dot(m1.row1, v),
+                Vector4.Dot(m1.row2, v),
+                Vector4.Dot(m1.row3, v),
+                Vector4.Dot(m1.row4, v));
         }
 
         public static Vector4 operator *(Vector4 v, Matrix4 m1)
         {
-            return new Vector4(v.X * m1[0].X + v.Y * m1[1].X + v.Z * m1[2].X + v.W * m1[3].X,
-                v.X * m1[0].Y + v.Y * m1[1].Y + v.Z * m1[2].Y + v.W * m1[3].Y,
-                v.X * m1[0].Z + v.Y * m1[1].Z + v.Z * m1[2].Z + v.W * m1[3].Z,
-                v.X * m1[0].W + v.Y * m1[1].W + v.Z * m1[2].W + v.W * m1[3].W);
+            return m1.Transpose() * v;
         }
 
         public Vector4 this[int a]
@@ -414,10 +400,11 @@ namespace OpenGL
         /// <returns>A Matrix4 object that contains the transposed matrix.</returns>
         public Matrix4 Transpose()
         {
-            return new Matrix4(new Vector4(this[0].X, this[1].X, this[2].X, this[3].X),
-                new Vector4(this[0].Y, this[1].Y, this[2].Y, this[3].Y),
-                new Vector4(this[0].Z, this[1].Z, this[2].Z, this[3].Z),
-                new Vector4(this[0].W, this[1].W, this[2].W, this[3].W));
+            return new Matrix4(
+                new Vector4(row1.X, row2.X, row3.X, row4.X),
+                new Vector4(row1.Y, row2.Y, row3.Y, row4.Y),
+                new Vector4(row1.Z, row2.Z, row3.Z, row4.Z),
+                new Vector4(row1.W, row2.W, row3.W, row4.W));
         }
 
         /// <summary>
@@ -476,8 +463,12 @@ namespace OpenGL
         /// <returns>Floating array that represents that Matrix4.</returns>
         public float[] ToFloat()
         {
-            return new float[] { this[0].X, this[0].Y, this[0].Z, this[0].W, this[1].X, this[1].Y, this[1].Z, this[1].W,
-                this[2].X, this[2].Y, this[2].Z, this[2].W, this[3].X, this[3].Y, this[3].Z, this[3].W };
+            float[] elements = new float[16];
+            row1.CopyTo(elements, 0);
+            row2.CopyTo(elements, 4);
+            row3.CopyTo(elements, 8);
+            row4.CopyTo(elements, 12);
+            return elements;
         }
 
         /// <summary>

--- a/OpenGL/Math/Matrix4.cs
+++ b/OpenGL/Math/Matrix4.cs
@@ -94,14 +94,14 @@ namespace OpenGL
             }
         }
 
-        public static bool operator ==(Matrix4 m1, Matrix4 m2)
+        public static bool operator ==(in Matrix4 m1, in Matrix4 m2)
         {
-            return (m1[0] == m2[0] && m1[1] == m2[1] && m1[2] == m2[2] && m1[3] == m2[3]);
+            return (m1.row1 == m2.row1 && m1.row2 == m2.row2 && m1.row3 == m2.row3 && m1.row4 == m2.row4);
         }
 
-        public static bool operator !=(Matrix4 m1, Matrix4 m2)
+        public static bool operator !=(in Matrix4 m1, in Matrix4 m2)
         {
-            return (m1[0] != m2[0] || m1[1] != m2[1] || m1[2] != m2[2] || m1[3] != m2[3]);
+            return !(m1 == m2);
         }
 
         public override bool Equals(object obj)

--- a/OpenGLUnitTests/Matrix4Tests.cs
+++ b/OpenGLUnitTests/Matrix4Tests.cs
@@ -104,6 +104,74 @@ namespace OpenGLUnitTests
         }
 
         [TestMethod]
+        public void MatrixMultiplyByVector3()
+        {
+            Vector4 v4 = new Vector4(0, 1, 2, 3);
+            Vector4 v3 = new Vector4(4, 5, 6, 7);
+            Vector4 v2 = new Vector4(8, 9, 10, 11);
+            Vector4 v1 = new Vector4(12, 13, 14, 15);
+
+            Matrix4 matrix = new Matrix4(v1, v2, v3, v4);
+            Vector3 vector = new Vector3(3, 7, -1);
+            Vector3 mult = matrix * vector;
+
+            Vector4 vector4 = new Vector4(vector, 0);
+            Assert.AreEqual(mult.X, Vector4.Dot(matrix[0], vector4));
+            Assert.AreEqual(mult.Y, Vector4.Dot(matrix[1], vector4));
+            Assert.AreEqual(mult.Z, Vector4.Dot(matrix[2], vector4));
+        }
+
+        [TestMethod]
+        public void MatrixMultiplyByVector4()
+        {
+            Vector4 v4 = new Vector4(0, 1, 2, 3);
+            Vector4 v3 = new Vector4(4, 5, 6, 7);
+            Vector4 v2 = new Vector4(8, 9, 10, 11);
+            Vector4 v1 = new Vector4(12, 13, 14, 15);
+
+            Matrix4 matrix = new Matrix4(v1, v2, v3, v4);
+            Vector4 vector = new Vector4(3, 7, -1, 4);
+            Vector4 mult = matrix * vector;
+
+            Assert.AreEqual(mult.X, Vector4.Dot(matrix[0], vector));
+            Assert.AreEqual(mult.Y, Vector4.Dot(matrix[1], vector));
+            Assert.AreEqual(mult.Z, Vector4.Dot(matrix[2], vector));
+            Assert.AreEqual(mult.W, Vector4.Dot(matrix[3], vector));
+        }
+
+        [TestMethod]
+        public void Vector4MultiplyByMatrix()
+        {
+            Vector4 v1 = new Vector4(0, 1, 2, 3);
+            Vector4 v2 = new Vector4(4, 5, 6, 7);
+            Vector4 v3 = new Vector4(8, 9, 10, 11);
+            Vector4 v4 = new Vector4(12, 13, 14, 15);
+
+            Matrix4 matrix = new Matrix4(v1, v2, v3, v4);
+            Vector4 vector = new Vector4(5, 6, 7, 8);
+
+            Vector4 actual = vector * matrix;
+            Vector4 expected = new Vector4(176, 202, 228, 254);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Vector3MultiplyByMatrix()
+        {
+            Vector4 v1 = new Vector4(0, 1, 2, 3);
+            Vector4 v2 = new Vector4(4, 5, 6, 7);
+            Vector4 v3 = new Vector4(8, 9, 10, 11);
+            Vector4 v4 = new Vector4(12, 13, 14, 15);
+
+            Matrix4 matrix = new Matrix4(v1, v2, v3, v4);
+            Vector3 vector = new Vector3(5, 6, 7);
+
+            Vector3 actual = vector * matrix;
+            Vector3 expected = new Vector3(80, 98, 116);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
         public void MatrixDivideByFloat()
         {
             Vector4 v4 = new Vector4(0, 1, 2, 3);
@@ -142,6 +210,26 @@ namespace OpenGLUnitTests
             // make sure the diff between the identity matrix and the float[] is less than e-8
             for (int i = 0; i < identity.Length; i++)
                 Assert.IsTrue(identity[i] - Matrix4.Identity[i / 4].Get(i % 4) < 10e-8);
+        }
+
+        [TestMethod]
+        public void MatrixTranspose()
+        {
+            Vector4 v1 = new Vector4( 0,  1,  2,  3);
+            Vector4 v2 = new Vector4( 4,  5,  6,  7);
+            Vector4 v3 = new Vector4( 8,  9, 10, 11);
+            Vector4 v4 = new Vector4(12, 13, 14, 15);
+
+            Vector4 v1t = new Vector4(0, 4,  8, 12);
+            Vector4 v2t = new Vector4(1, 5,  9, 13);
+            Vector4 v3t = new Vector4(2, 6, 10, 14);
+            Vector4 v4t = new Vector4(3, 7, 11, 15);
+
+            Matrix4 matrix = new Matrix4(v1, v2, v3, v4);
+            Matrix4 expected = new Matrix4(v1t, v2t, v3t, v4t);
+            Matrix4 actual = matrix.Transpose();
+
+            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/OpenGLUnitTests/Matrix4Tests.cs
+++ b/OpenGLUnitTests/Matrix4Tests.cs
@@ -189,6 +189,99 @@ namespace OpenGLUnitTests
         }
 
         [TestMethod]
+        public void MatrixEqualityOpMatrix()
+        {
+            Vector4 v1 = new Vector4(0, 1, 2, 3);
+            Vector4 v2 = new Vector4(4, 5, 6, 7);
+            Vector4 v3 = new Vector4(8, 9, 10, 11);
+            Vector4 v4 = new Vector4(12, 13, 14, 15);
+
+            Assert.IsTrue(new Matrix4(v1, v2, v3, v4) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v1, v2, v4, v3) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v1, v3, v2, v4) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v1, v3, v4, v2) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v1, v4, v2, v3) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v1, v4, v3, v2) == new Matrix4(v1, v2, v3, v4));
+
+            Assert.IsFalse(new Matrix4(v2, v1, v3, v4) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v2, v1, v4, v3) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v2, v3, v1, v4) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v2, v3, v4, v1) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v2, v4, v1, v3) == new Matrix4(v1, v2, v3, v4));
+            Assert.IsFalse(new Matrix4(v2, v4, v3, v1) == new Matrix4(v1, v2, v3, v4));
+        }
+
+        [TestMethod]
+        public void MatrixInEqualityOpMatrix()
+        {
+            Vector4 v1 = new Vector4(0, 1, 2, 3);
+            Vector4 v2 = new Vector4(4, 5, 6, 7);
+            Vector4 v3 = new Vector4(8, 9, 10, 11);
+            Vector4 v4 = new Vector4(12, 13, 14, 15);
+
+            Assert.IsFalse(new Matrix4(v1, v2, v3, v4) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v1, v2, v4, v3) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v1, v3, v2, v4) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v1, v3, v4, v2) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v1, v4, v2, v3) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v1, v4, v3, v2) != new Matrix4(v1, v2, v3, v4));
+
+            Assert.IsTrue(new Matrix4(v2, v1, v3, v4) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v2, v1, v4, v3) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v2, v3, v1, v4) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v2, v3, v4, v1) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v2, v4, v1, v3) != new Matrix4(v1, v2, v3, v4));
+            Assert.IsTrue(new Matrix4(v2, v4, v3, v1) != new Matrix4(v1, v2, v3, v4));
+        }
+
+        [TestMethod]
+        public void MatrixEqualsMatrix()
+        {
+            Vector4 v1 = new Vector4(0, 1, 2, 3);
+            Vector4 v2 = new Vector4(4, 5, 6, 7);
+            Vector4 v3 = new Vector4(8, 9, 10, 11);
+            Vector4 v4 = new Vector4(12, 13, 14, 15);
+
+            Assert.IsTrue(new Matrix4(v1, v2, v3, v4).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v2, v4, v3).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v3, v2, v4).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v3, v4, v2).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v4, v2, v3).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v4, v3, v2).Equals(new Matrix4(v1, v2, v3, v4)));
+
+            Assert.IsFalse(new Matrix4(v2, v1, v3, v4).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v1, v4, v3).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v3, v1, v4).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v3, v4, v1).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v1, v3).Equals(new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals(new Matrix4(v1, v2, v3, v4)));
+        }
+
+        [TestMethod]
+        public void MatrixEqualsObject()
+        {
+            Vector4 v1 = new Vector4(0, 1, 2, 3);
+            Vector4 v2 = new Vector4(4, 5, 6, 7);
+            Vector4 v3 = new Vector4(8, 9, 10, 11);
+            Vector4 v4 = new Vector4(12, 13, 14, 15);
+
+            Assert.IsTrue(new Matrix4(v1, v2, v3, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v2, v4, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v3, v2, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v3, v4, v2).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v4, v2, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v4, v3, v2).Equals((object)new Matrix4(v1, v2, v3, v4)));
+
+            Assert.IsFalse(new Matrix4(v2, v1, v3, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v1, v4, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v3, v1, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v3, v4, v1).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v1, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals(new object()));
+        }
+
+        [TestMethod]
         public void MatrixToFloat()
         {
             float[] array = new float[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 };


### PR DESCRIPTION
Took a stab at optimizing `Matrix4`, `Frustum` and `BoundingBox`. This PR is mainly focused on `Matrix4` optimizations.

Added tests for the `Matrix4` operators that were missing tests that i optimized. 

No uint tests for both `Frustum` and `BoundingBox` but that's mainly because it's difficult to make unit tests for them. I've instead  tested them manually. The optimizations for these two are also very small and it should be easy to see that the old and new code are equivalent.

The optimizations in `Matrix4` are mainly done by replacing uses of the index operator with the row it would return and by vectorizing  math operations.

`Matrix4` benchmarks using `System.Numerics`
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18362.1016 (1903/May2019Update/19H1)
.NET Core SDK=5.0.100-preview.6.20318.15
  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT


```
|                Method |       Mean |     Error |    StdDev |
|---------------------- |-----------:|----------:|----------:|
|         MultMatMatOld | 403.704 ns | 1.2245 ns | 1.1454 ns |
|         MultMatMatNew |  36.361 ns | 0.3194 ns | 0.2988 ns |
|        MultMatVec3Old |  31.207 ns | 0.1240 ns | 0.1160 ns |
|        MultMatVec3New |   6.711 ns | 0.1152 ns | 0.1078 ns |
|        MultMatVec4Old |  50.112 ns | 0.1868 ns | 0.1656 ns |
|        MultMatVec4New |   6.695 ns | 0.0609 ns | 0.0509 ns |
|        MultVec4MatOld |  49.080 ns | 0.1196 ns | 0.1060 ns |
|        MultVec4MatNew |  49.138 ns | 0.1861 ns | 0.1554 ns |
|          MultTransOld |  47.183 ns | 0.2741 ns | 0.2430 ns |
|          MultTransNew |   6.657 ns | 0.0552 ns | 0.0516 ns |
|        MultToFloatOld |  53.761 ns | 0.2290 ns | 0.1912 ns |
|        MultToFloatNew |  11.199 ns | 0.1325 ns | 0.1107 ns |
|   MatEqualityOpMatOld |  11.473 ns | 0.0778 ns | 0.0689 ns |
|   MatEqualityOpMatNew |   2.968 ns | 0.0377 ns | 0.0352 ns |
| MatInEqualityOpMatOld |  11.524 ns | 0.0564 ns | 0.0500 ns |
| MatInEqualityOpMatNew |   3.589 ns | 0.0232 ns | 0.0194 ns |
|       MatEqualsMatOld |  11.190 ns | 0.0954 ns | 0.0846 ns |
|       MatEqualsMatNew |   3.937 ns | 0.0247 ns | 0.0206 ns |
|       MatEqualsObjOld |  13.710 ns | 0.1509 ns | 0.1411 ns |
|       MatEqualsObjNew |   6.896 ns | 0.0563 ns | 0.0499 ns |