### PR TITLE
Vector Refactorings

### DIFF
--- a/OpenGL/Math/Vector2.cs
+++ b/OpenGL/Math/Vector2.cs
@@ -1,7 +1,7 @@
-﻿#if USE_NUMERICS
+﻿using System;
+#if USE_NUMERICS
 using System.Numerics;
 #else
-using System;
 using System.Runtime.InteropServices;
 #endif
 
@@ -320,6 +320,24 @@ namespace OpenGL
         }
         #endregion
     }
-#else
 #endif
+
+    /// <summary>
+    /// Extension methods for the Vector4 structure.
+    /// </summary>
+    public static class Vector2Extensions
+    {
+        /// <summary>
+        /// Provide an accessor for each of the elements of the Vector structure.
+        /// </summary>
+        /// <param name="v">The Vector2 to access.</param>
+        /// <param name="index">The element to access (0 = X, 1 = Y).</param>
+        /// <returns>The element of the Vector2 as indexed by i.</returns>
+        public static float Get(this Vector2 tv, int index)
+        {
+            if (index != 0 && index != 1)
+                throw new ArgumentOutOfRangeException("index");
+            return (index == 0 ? tv.X : tv.Y);
+        }
+    }
 }

--- a/OpenGL/Math/Vector2.cs
+++ b/OpenGL/Math/Vector2.cs
@@ -343,11 +343,11 @@ namespace OpenGL
         /// </summary>
         /// <param name="v">The Vector2 to access.</param>
         /// <param name="index">The element to access (0 = X, 1 = Y).</param>
-        /// <returns>The element of the Vector2 as indexed by i.</returns>
+        /// <returns>The element of the Vector2 as indexed by index.</returns>
         public static float Get(this Vector2 tv, int index)
         {
             if (index != 0 && index != 1)
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             return (index == 0 ? tv.X : tv.Y);
         }
     }

--- a/OpenGL/Math/Vector2.cs
+++ b/OpenGL/Math/Vector2.cs
@@ -318,6 +318,17 @@ namespace OpenGL
             v1 = v2;
             v2 = t;
         }
+
+        /// <summary>
+        /// Copies the elements of the vector to a specified array.
+        /// </summary>
+        /// <param name="array">The destination array.</param>
+        /// <param name="offset">The index at which to copy the first element of the vector.</param>
+        public void CopyTo(float[] array, int offset)
+        {
+            array[offset + 0] = X;
+            array[offset + 1] = Y;
+        }
         #endregion
     }
 #endif

--- a/OpenGL/Math/Vector3.cs
+++ b/OpenGL/Math/Vector3.cs
@@ -1,7 +1,7 @@
-﻿#if USE_NUMERICS
+﻿using System;
+#if USE_NUMERICS
 using System.Numerics;
 #else
-using System;
 using System.Runtime.InteropServices;
 #endif
 
@@ -235,16 +235,6 @@ namespace OpenGL
         }
 
         /// <summary>
-        /// Performs the Vector3 scalar dot product.
-        /// </summary>
-        /// <param name="v">Second dot product term</param>
-        /// <returns>Vector3.Dot(this, v)</returns>
-        public float Dot(Vector3 v)
-        {
-            return Vector3.Dot(this, v);
-        }
-
-        /// <summary>
         /// A System.Numerics compatible version of SquaredLength.
         /// </summary>
         /// <returns>Returns the squared length of the Vector3 structure.</returns>
@@ -275,16 +265,6 @@ namespace OpenGL
         }
 
         /// <summary>
-        /// Normalizes the Vector3 structure to have a peak value of one.
-        /// </summary>
-        /// <returns>if (Length = 0) return Zero; else return Vector3(x,y,z)/Length</returns>
-        public Vector3 Normalize()
-        {
-            if (Length() == 0) return Zero;
-            else return new Vector3(X, Y, Z) / Length();
-        }
-
-        /// <summary>
         /// Checks to see if any value (x, y, z) are within 0.0001 of 0.
         /// If so this method truncates that value to zero.
         /// </summary>
@@ -295,28 +275,6 @@ namespace OpenGL
             float _y = (Math.Abs(Y) - 0.0001f < 0) ? 0 : Y;
             float _z = (Math.Abs(Z) - 0.0001f < 0) ? 0 : Z;
             return new Vector3(_x, _y, _z);
-        }
-
-        /// <summary>
-        /// Store the minimum values of x, y, and z between the two vectors.
-        /// </summary>
-        /// <param name="v">Vector to check against</param>
-        public void TakeMin(Vector3 v)
-        {
-            if (v.X < X) X = v.X;
-            if (v.Y < Y) Y = v.Y;
-            if (v.Z < Z) Z = v.Z;
-        }
-
-        /// <summary>
-        /// Store the maximum values of x, y, and z between the two vectors.
-        /// </summary>
-        /// <param name="v">Vector to check against</param>
-        public void TakeMax(Vector3 v)
-        {
-            if (v.X > X) X = v.X;
-            if (v.Y > Y) Y = v.Y;
-            if (v.Z > Z) Z = v.Z;
         }
 
         /// <summary>
@@ -624,20 +582,22 @@ namespace OpenGL
         {
             return q * v;
         }
-        
+
         /// <summary>
-        /// Provide an accessor for each of the elements of the Vector structure.
+        /// Copies the elements of the vector to a specified array.
         /// </summary>
-        /// <param name="v">The Vector3 to access.</param>
-        /// <param name="index">The element to access (0 = X, 1 = Y, 2 = Z).</param>
-        /// <returns>The element of the Vector3 as indexed by i.</returns>
-        public float Get(int index)
+        /// <param name="array">The destination array.</param>
+        /// <param name="offset">The index at which to copy the first element of the vector.</param>
+        public void CopyTo(float[] array, int offset)
         {
-            return (index == 0 ? X : (index == 1 ? Y : Z));
+            array[offset + 0] = X;
+            array[offset + 1] = Y;
+            array[offset + 2] = Z;
         }
         #endregion
     }
-#else
+#endif
+
     /// <summary>
     /// Extension methods for the Vector3 structure.
     /// </summary>
@@ -697,8 +657,9 @@ namespace OpenGL
         /// <returns>The element of the Vector3 as indexed by i.</returns>
         public static float Get(this Vector3 v, int index)
         {
+            if (index < 0 || index > 2)
+                throw new ArgumentOutOfRangeException("index");
             return (index == 0 ? v.X : (index == 1 ? v.Y : v.Z));
         }
     }
-#endif
 }

--- a/OpenGL/Math/Vector3.cs
+++ b/OpenGL/Math/Vector3.cs
@@ -658,7 +658,7 @@ namespace OpenGL
         public static float Get(this Vector3 v, int index)
         {
             if (index < 0 || index > 2)
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             return (index == 0 ? v.X : (index == 1 ? v.Y : v.Z));
         }
     }

--- a/OpenGL/Math/Vector4.cs
+++ b/OpenGL/Math/Vector4.cs
@@ -1,7 +1,7 @@
-﻿#if USE_NUMERICS
+﻿using System;
+#if USE_NUMERICS
 using System.Numerics;
 #else
-using System;
 using System.Runtime.InteropServices;
 #endif
 
@@ -13,7 +13,7 @@ namespace OpenGL
     {
         public float X, Y, Z, W;
 
-    #region Static Constructors
+        #region Static Constructors
         public static Vector4 Zero
         {
             get { return new Vector4(0.0f, 0.0f, 0.0f, 0.0f); }
@@ -45,7 +45,7 @@ namespace OpenGL
         }
         #endregion
 
-    #region Operators
+        #region Operators
         public static Vector4 operator +(Vector4 v1, Vector4 v2)
         {
             return new Vector4(v1.X + v2.X, v1.Y + v2.Y, v1.Z + v2.Z, v1.W + v2.W);
@@ -122,7 +122,7 @@ namespace OpenGL
         }
         #endregion
 
-    #region Constructors
+        #region Constructors
         /// <summary>Creates a Vector4 structure whose elements have the specified values.</summary>
         /// <param name="x">The value to assign to the X field.</param>
         /// <param name="y">The value to assign to the Y field.</param>
@@ -130,9 +130,9 @@ namespace OpenGL
         /// <param name="w">The value to assign to the W field.</param>
         public Vector4(float x, float y, float z, float w)
         {
-            X = x; 
-            Y = y; 
-            Z = z; 
+            X = x;
+            Y = y;
+            Z = z;
             W = w;
         }
 
@@ -141,9 +141,9 @@ namespace OpenGL
         /// <param name="w">The value to assign to the W field.</param>
         public Vector4(Vector3 v, float w)
         {
-            X = v.X; 
-            Y = v.Y; 
-            Z = v.Z; 
+            X = v.X;
+            Y = v.Y;
+            Z = v.Z;
             W = w;
         }
 
@@ -167,7 +167,7 @@ namespace OpenGL
         }
         #endregion
 
-    #region Overrides
+        #region Overrides
         public override bool Equals(object obj)
         {
             if (!(obj is Vector4)) return false;
@@ -208,21 +208,9 @@ namespace OpenGL
 
             return new Vector4(float.Parse(split[0]), float.Parse(split[1]), float.Parse(split[2]), float.Parse(split[3]));
         }
-
-        public float Get(int index)
-        {
-            switch (index)
-            {
-                case 0: return X;
-                case 1: return Y;
-                case 2: return Z;
-                case 3: return W;
-                default: return 0;  // error case
-            }
-        }
         #endregion
 
-    #region Properties
+        #region Properties
         /// <summary>
         /// Get the length of the Vector4 structure.
         /// </summary>
@@ -240,7 +228,7 @@ namespace OpenGL
         }
         #endregion
 
-    #region Methods
+        #region Methods
         /// <summary>
         /// Vector4 scalar dot product.
         /// </summary>
@@ -342,9 +330,23 @@ namespace OpenGL
             v1 = v2;
             v2 = t;
         }
+
+        /// <summary>
+        /// Copies the elements of the vector to a specified array.
+        /// </summary>
+        /// <param name="array">The destination array.</param>
+        /// <param name="offset">The index at which to copy the first element of the vector.</param>
+        public void CopyTo(float[] array, int offset)
+        {
+            array[offset + 0] = X;
+            array[offset + 1] = Y;
+            array[offset + 2] = Z;
+            array[offset + 3] = W;
+        }
         #endregion
     }
-#else
+#endif
+
     /// <summary>
     /// Extension methods for the Vector4 structure.
     /// </summary>
@@ -364,9 +366,8 @@ namespace OpenGL
                 case 1: return v.Y;
                 case 2: return v.Z;
                 case 3: return v.W;
-                default: return 0;  // error case
+                default: throw new ArgumentOutOfRangeException("index");
             }
         }
     }
-#endif
 }

--- a/OpenGL/Math/Vector4.cs
+++ b/OpenGL/Math/Vector4.cs
@@ -366,7 +366,7 @@ namespace OpenGL
                 case 1: return v.Y;
                 case 2: return v.Z;
                 case 3: return v.W;
-                default: throw new ArgumentOutOfRangeException("index");
+                default: throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
     }


### PR DESCRIPTION
## General Notes

This change adds `Get` to the `Vector2` class, removes code duplication, adds `CopyTo` for vectors without System.Numerics and adds an exception for `Get` if the index is out of range.

## Testing

Limited testing - made sure it compiled and ran a few local tests.