### PR TITLE
Fixed matrix4 multiplication

### DIFF
--- a/OpenGL/Math/Matrix4.cs
+++ b/OpenGL/Math/Matrix4.cs
@@ -32,12 +32,12 @@ namespace OpenGL
 
         public static Matrix4 operator *(Matrix4 m, Matrix4 m2)
         {
-            Matrix4 m2t = m2.Transpose();
+            Matrix4 mt = m.Transpose();
             return new Matrix4(
-                m2t * m.row1,
-                m2t * m.row2,
-                m2t * m.row3,
-                m2t * m.row4);
+                mt * m2.row1,
+                mt * m2.row2,
+                mt * m2.row3,
+                mt * m2.row4);
         }
 
         public static Matrix4 operator *(Matrix4 m1, float d)

--- a/OpenGL/Math/Matrix4.cs
+++ b/OpenGL/Math/Matrix4.cs
@@ -32,12 +32,12 @@ namespace OpenGL
 
         public static Matrix4 operator *(Matrix4 m, Matrix4 m2)
         {
-            Matrix4 mt = m.Transpose();
+            Matrix4 m2t = m2.Transpose();
             return new Matrix4(
-                mt * m2.row1,
-                mt * m2.row2,
-                mt * m2.row3,
-                mt * m2.row4);
+                m2t * m.row1,
+                m2t * m.row2,
+                m2t * m.row3,
+                m2t * m.row4);
         }
 
         public static Matrix4 operator *(Matrix4 m1, float d)

--- a/OpenGLUnitTests/GeometryTests.cs
+++ b/OpenGLUnitTests/GeometryTests.cs
@@ -1,9 +1,12 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenGL;
 using System;
-using System.Buffers;
-using System.Numerics;
 using System.Runtime.InteropServices;
+
+#if USE_NUMERICS
+using System.Numerics;
+#else
+using OpenGL;
+#endif
 
 namespace OpenGLUnitTests
 {

--- a/OpenGLUnitTests/GeometryTests.cs
+++ b/OpenGLUnitTests/GeometryTests.cs
@@ -4,9 +4,8 @@ using System.Runtime.InteropServices;
 
 #if USE_NUMERICS
 using System.Numerics;
-#else
-using OpenGL;
 #endif
+using OpenGL;
 
 namespace OpenGLUnitTests
 {

--- a/OpenGLUnitTests/Matrix2Tests.cs
+++ b/OpenGLUnitTests/Matrix2Tests.cs
@@ -3,9 +3,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #if USE_NUMERICS
 using System.Numerics;
-#else
-using OpenGL;
 #endif
+using OpenGL;
 
 namespace OpenGLUnitTests
 {

--- a/OpenGLUnitTests/Matrix2Tests.cs
+++ b/OpenGLUnitTests/Matrix2Tests.cs
@@ -1,8 +1,11 @@
 ﻿using System;
-using System.Numerics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#if USE_NUMERICS
+using System.Numerics;
+#else
 using OpenGL;
+#endif
 
 namespace OpenGLUnitTests
 {

--- a/OpenGLUnitTests/Matrix4Tests.cs
+++ b/OpenGLUnitTests/Matrix4Tests.cs
@@ -1,8 +1,10 @@
-﻿using System;
-using System.Numerics;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#if USE_NUMERICS
+using System.Numerics;
+#else
 using OpenGL;
+#endif
 
 namespace OpenGLUnitTests
 {
@@ -23,7 +25,7 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixCreateFromArray()
         {
-            Matrix4 matrix = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+            Matrix4 matrix = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
 
             Assert.AreEqual(matrix[0], new Vector4(0, 1, 2, 3));
             Assert.AreEqual(matrix[1], new Vector4(4, 5, 6, 7));
@@ -50,8 +52,8 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixAdd()
         {
-            Matrix4 m1 = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
-            Matrix4 m2 = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
+            Matrix4 m1 = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+            Matrix4 m2 = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
             Matrix4 sum = m1 + m2;
 
             Assert.AreEqual(sum[0], m1[0] + m2[0]);
@@ -63,8 +65,8 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixSubtract()
         {
-            Matrix4 m1 = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
-            Matrix4 m2 = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
+            Matrix4 m1 = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+            Matrix4 m2 = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
             Matrix4 difference = m1 - m2;
 
             Assert.AreEqual(difference[0], m1[0] - m2[0]);
@@ -76,14 +78,28 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixMultiply()
         {
-            Matrix4 m1 = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
-            Matrix4 m2 = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
-            Matrix4 mult = m1 * m2;
+            Matrix4 m1 = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+            Matrix4 m2 = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
+            Matrix4 mult = m2 * m1;
 
-            Assert.AreEqual(mult[0], new Vector4(220, 230, 190, 100));
-            Assert.AreEqual(mult[1], new Vector4(740, 710, 630, 500));
-            Assert.AreEqual(mult[2], new Vector4(1260, 1190, 1070, 900));
-            Assert.AreEqual(mult[3], new Vector4(1780, 1670, 1510, 1300));
+            Assert.AreEqual(new Vector4(220, 230, 190, 100), mult[0]);
+            Assert.AreEqual(new Vector4(740, 710, 630, 500), mult[1]);
+            Assert.AreEqual(new Vector4(1260, 1190, 1070, 900), mult[2]);
+            Assert.AreEqual(new Vector4(1780, 1670, 1510, 1300), mult[3]);
+        }
+        
+        [TestMethod]
+        public void MatrixMultiplyMultipleMatrix()
+        {
+            Matrix4 m1 = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+            Matrix4 m2 = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
+            Matrix4 m3 = new Matrix4(new double[] {100, 200, 300, 400, 500, 100, 200, 300, 400, 500, 100, 200, 300, 400, 500, 100});
+            Matrix4 mult = m3 * m2 * m1;
+
+            Assert.AreEqual(new Vector4(243000, 202000, 181000, 205000), mult[0]);
+            Assert.AreEqual(new Vector4(831000, 734000, 677000, 685000), mult[1]);
+            Assert.AreEqual(new Vector4(1419000, 1266000, 1173000, 1165000), mult[2]);
+            Assert.AreEqual(new Vector4(2007000, 1798000, 1669000, 1645000), mult[3]);
         }
 
         [TestMethod]
@@ -265,26 +281,26 @@ namespace OpenGLUnitTests
             Vector4 v3 = new Vector4(8, 9, 10, 11);
             Vector4 v4 = new Vector4(12, 13, 14, 15);
 
-            Assert.IsTrue(new Matrix4(v1, v2, v3, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v2, v4, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v3, v2, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v3, v4, v2).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v4, v2, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v4, v3, v2).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsTrue(new Matrix4(v1, v2, v3, v4).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v2, v4, v3).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v3, v2, v4).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v3, v4, v2).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v4, v2, v3).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v4, v3, v2).Equals((object) new Matrix4(v1, v2, v3, v4)));
 
-            Assert.IsFalse(new Matrix4(v2, v1, v3, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v1, v4, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v3, v1, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v3, v4, v1).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v4, v1, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v1, v3, v4).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v1, v4, v3).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v3, v1, v4).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v3, v4, v1).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v1, v3).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals((object) new Matrix4(v1, v2, v3, v4)));
             Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals(new object()));
         }
 
         [TestMethod]
         public void MatrixToFloat()
         {
-            float[] array = new float[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 };
+            float[] array = new float[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10};
             Matrix4 matrix = new Matrix4(array);
             float[] comparison = matrix.ToFloat();
 
@@ -296,7 +312,7 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixInverse()
         {
-            Matrix4 matrix = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
+            Matrix4 matrix = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
             Matrix4 inverse = matrix.Inverse();
             float[] identity = (matrix * inverse).ToFloat();
 
@@ -308,13 +324,13 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixTranspose()
         {
-            Vector4 v1 = new Vector4( 0,  1,  2,  3);
-            Vector4 v2 = new Vector4( 4,  5,  6,  7);
-            Vector4 v3 = new Vector4( 8,  9, 10, 11);
+            Vector4 v1 = new Vector4(0, 1, 2, 3);
+            Vector4 v2 = new Vector4(4, 5, 6, 7);
+            Vector4 v3 = new Vector4(8, 9, 10, 11);
             Vector4 v4 = new Vector4(12, 13, 14, 15);
 
-            Vector4 v1t = new Vector4(0, 4,  8, 12);
-            Vector4 v2t = new Vector4(1, 5,  9, 13);
+            Vector4 v1t = new Vector4(0, 4, 8, 12);
+            Vector4 v2t = new Vector4(1, 5, 9, 13);
             Vector4 v3t = new Vector4(2, 6, 10, 14);
             Vector4 v4t = new Vector4(3, 7, 11, 15);
 

--- a/OpenGLUnitTests/Matrix4Tests.cs
+++ b/OpenGLUnitTests/Matrix4Tests.cs
@@ -2,9 +2,8 @@
 
 #if USE_NUMERICS
 using System.Numerics;
-#else
-using OpenGL;
 #endif
+using OpenGL;
 
 namespace OpenGLUnitTests
 {

--- a/OpenGLUnitTests/Matrix4Tests.cs
+++ b/OpenGLUnitTests/Matrix4Tests.cs
@@ -82,12 +82,12 @@ namespace OpenGLUnitTests
             Matrix4 m2 = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
             Matrix4 mult = m1 * m2;
 
-            Assert.AreEqual(new Vector4(220, 230, 190, 100),mult[0]);
-            Assert.AreEqual(new Vector4(740, 710, 630, 500),mult[1]);
-            Assert.AreEqual(new Vector4(1260, 1190, 1070, 900),mult[2]);
-            Assert.AreEqual(new Vector4(1780, 1670, 1510, 1300),mult[3]);
+            Assert.AreEqual(new Vector4(220, 230, 190, 100), mult[0]);
+            Assert.AreEqual(new Vector4(740, 710, 630, 500), mult[1]);
+            Assert.AreEqual(new Vector4(1260, 1190, 1070, 900), mult[2]);
+            Assert.AreEqual(new Vector4(1780, 1670, 1510, 1300), mult[3]);
         }
-        
+
         [TestMethod]
         public void MatrixMultiplyMultipleMatrix()
         {
@@ -324,13 +324,13 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixTranspose()
         {
-            Vector4 v1 = new Vector4( 0,  1,  2,  3);
-            Vector4 v2 = new Vector4( 4,  5,  6,  7);
-            Vector4 v3 = new Vector4( 8,  9, 10, 11);
+            Vector4 v1 = new Vector4(0, 1, 2, 3);
+            Vector4 v2 = new Vector4(4, 5, 6, 7);
+            Vector4 v3 = new Vector4(8, 9, 10, 11);
             Vector4 v4 = new Vector4(12, 13, 14, 15);
 
-            Vector4 v1t = new Vector4(0, 4,  8, 12);
-            Vector4 v2t = new Vector4(1, 5,  9, 13);
+            Vector4 v1t = new Vector4(0, 4, 8, 12);
+            Vector4 v2t = new Vector4(1, 5, 9, 13);
             Vector4 v3t = new Vector4(2, 6, 10, 14);
             Vector4 v4t = new Vector4(3, 7, 11, 15);
 

--- a/OpenGLUnitTests/Matrix4Tests.cs
+++ b/OpenGLUnitTests/Matrix4Tests.cs
@@ -25,7 +25,7 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixCreateFromArray()
         {
-            Matrix4 matrix = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+            Matrix4 matrix = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
 
             Assert.AreEqual(matrix[0], new Vector4(0, 1, 2, 3));
             Assert.AreEqual(matrix[1], new Vector4(4, 5, 6, 7));
@@ -52,8 +52,8 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixAdd()
         {
-            Matrix4 m1 = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
-            Matrix4 m2 = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
+            Matrix4 m1 = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+            Matrix4 m2 = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
             Matrix4 sum = m1 + m2;
 
             Assert.AreEqual(sum[0], m1[0] + m2[0]);
@@ -65,8 +65,8 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixSubtract()
         {
-            Matrix4 m1 = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
-            Matrix4 m2 = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
+            Matrix4 m1 = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+            Matrix4 m2 = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
             Matrix4 difference = m1 - m2;
 
             Assert.AreEqual(difference[0], m1[0] - m2[0]);
@@ -78,23 +78,23 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixMultiply()
         {
-            Matrix4 m1 = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
-            Matrix4 m2 = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
-            Matrix4 mult = m2 * m1;
+            Matrix4 m1 = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+            Matrix4 m2 = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
+            Matrix4 mult = m1 * m2;
 
-            Assert.AreEqual(new Vector4(220, 230, 190, 100), mult[0]);
-            Assert.AreEqual(new Vector4(740, 710, 630, 500), mult[1]);
-            Assert.AreEqual(new Vector4(1260, 1190, 1070, 900), mult[2]);
-            Assert.AreEqual(new Vector4(1780, 1670, 1510, 1300), mult[3]);
+            Assert.AreEqual(new Vector4(220, 230, 190, 100),mult[0]);
+            Assert.AreEqual(new Vector4(740, 710, 630, 500),mult[1]);
+            Assert.AreEqual(new Vector4(1260, 1190, 1070, 900),mult[2]);
+            Assert.AreEqual(new Vector4(1780, 1670, 1510, 1300),mult[3]);
         }
         
         [TestMethod]
         public void MatrixMultiplyMultipleMatrix()
         {
-            Matrix4 m1 = new Matrix4(new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
-            Matrix4 m2 = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
-            Matrix4 m3 = new Matrix4(new double[] {100, 200, 300, 400, 500, 100, 200, 300, 400, 500, 100, 200, 300, 400, 500, 100});
-            Matrix4 mult = m3 * m2 * m1;
+            Matrix4 m1 = new Matrix4(new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+            Matrix4 m2 = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
+            Matrix4 m3 = new Matrix4(new double[] { 100, 200, 300, 400, 500, 100, 200, 300, 400, 500, 100, 200, 300, 400, 500, 100 });
+            Matrix4 mult = m1 * m2 * m3;
 
             Assert.AreEqual(new Vector4(243000, 202000, 181000, 205000), mult[0]);
             Assert.AreEqual(new Vector4(831000, 734000, 677000, 685000), mult[1]);
@@ -281,26 +281,26 @@ namespace OpenGLUnitTests
             Vector4 v3 = new Vector4(8, 9, 10, 11);
             Vector4 v4 = new Vector4(12, 13, 14, 15);
 
-            Assert.IsTrue(new Matrix4(v1, v2, v3, v4).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v2, v4, v3).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v3, v2, v4).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v3, v4, v2).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v4, v2, v3).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v1, v4, v3, v2).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsTrue(new Matrix4(v1, v2, v3, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v2, v4, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v3, v2, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v3, v4, v2).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v4, v2, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v1, v4, v3, v2).Equals((object)new Matrix4(v1, v2, v3, v4)));
 
-            Assert.IsFalse(new Matrix4(v2, v1, v3, v4).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v1, v4, v3).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v3, v1, v4).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v3, v4, v1).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v4, v1, v3).Equals((object) new Matrix4(v1, v2, v3, v4)));
-            Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals((object) new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v1, v3, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v1, v4, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v3, v1, v4).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v3, v4, v1).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v1, v3).Equals((object)new Matrix4(v1, v2, v3, v4)));
+            Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals((object)new Matrix4(v1, v2, v3, v4)));
             Assert.IsFalse(new Matrix4(v2, v4, v3, v1).Equals(new object()));
         }
 
         [TestMethod]
         public void MatrixToFloat()
         {
-            float[] array = new float[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10};
+            float[] array = new float[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 };
             Matrix4 matrix = new Matrix4(array);
             float[] comparison = matrix.ToFloat();
 
@@ -312,7 +312,7 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixInverse()
         {
-            Matrix4 matrix = new Matrix4(new double[] {10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10});
+            Matrix4 matrix = new Matrix4(new double[] { 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10, 20, 30, 40, 50, 10 });
             Matrix4 inverse = matrix.Inverse();
             float[] identity = (matrix * inverse).ToFloat();
 
@@ -324,13 +324,13 @@ namespace OpenGLUnitTests
         [TestMethod]
         public void MatrixTranspose()
         {
-            Vector4 v1 = new Vector4(0, 1, 2, 3);
-            Vector4 v2 = new Vector4(4, 5, 6, 7);
-            Vector4 v3 = new Vector4(8, 9, 10, 11);
+            Vector4 v1 = new Vector4( 0,  1,  2,  3);
+            Vector4 v2 = new Vector4( 4,  5,  6,  7);
+            Vector4 v3 = new Vector4( 8,  9, 10, 11);
             Vector4 v4 = new Vector4(12, 13, 14, 15);
 
-            Vector4 v1t = new Vector4(0, 4, 8, 12);
-            Vector4 v2t = new Vector4(1, 5, 9, 13);
+            Vector4 v1t = new Vector4(0, 4,  8, 12);
+            Vector4 v2t = new Vector4(1, 5,  9, 13);
             Vector4 v3t = new Vector4(2, 6, 10, 14);
             Vector4 v4t = new Vector4(3, 7, 11, 15);
 

--- a/OpenGLUnitTests/OpenGLUnitTests.csproj
+++ b/OpenGLUnitTests/OpenGLUnitTests.csproj
@@ -35,6 +35,18 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'USE_NUMERICS|AnyCPU' ">
+    <OutputPath>bin\USE_NUMERICS\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;USE_NUMERICS</DefineConstants>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug USE_NUMERICS|AnyCPU' ">
+    <OutputPath>bin\Debug USE_NUMERICS\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug | USE_NUMERICS|AnyCPU' ">
+    <OutputPath>bin\Debug | USE_NUMERICS\</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />

--- a/OpenGLUnitTests/OpenGLUnitTests.sln
+++ b/OpenGLUnitTests/OpenGLUnitTests.sln
@@ -9,12 +9,14 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug USE_NUMERICS|Any CPU = Debug USE_NUMERICS|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D639107F-763A-409B-BCF1-3DCA0B66638B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D639107F-763A-409B-BCF1-3DCA0B66638B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D639107F-763A-409B-BCF1-3DCA0B66638B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D639107F-763A-409B-BCF1-3DCA0B66638B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D639107F-763A-409B-BCF1-3DCA0B66638B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D639107F-763A-409B-BCF1-3DCA0B66638B}.Debug USE_NUMERICS|Any CPU.ActiveCfg = Debug USE_NUMERICS|Any CPU
+		{D639107F-763A-409B-BCF1-3DCA0B66638B}.Debug USE_NUMERICS|Any CPU.Build.0 = Debug USE_NUMERICS|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenGLUnitTests/Vector3Tests.cs
+++ b/OpenGLUnitTests/Vector3Tests.cs
@@ -31,9 +31,7 @@ namespace OpenGLUnitTests
                 Vector3 v1 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
                 Vector3 v2 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
                 Vector3 a = v1;
-
                 a.TakeMin(v2);
-
                 Assert.AreEqual(a, new Vector3(Math.Min(v1.X, v2.X), Math.Min(v1.Y, v2.Y), Math.Min(v1.Z, v2.Z)));
             }
         }
@@ -72,10 +70,8 @@ namespace OpenGLUnitTests
 
                 Assert.AreEqual(Vector3.Abs(v1), new Vector3(Math.Abs(v1.X), Math.Abs(v1.Y), Math.Abs(v1.Z)));
                 Assert.AreEqual(Vector3.Add(v1, v2), new Vector3(v1.X + v2.X, v1.Y + v2.Y, v1.Z + v2.Z));
-                Assert.AreEqual(Vector3.Clamp(v1, v2, v3),
-                    new Vector3(Clamp(v1.X, v2.X, v3.X), Clamp(v1.Y, v2.Y, v3.Y), Clamp(v1.Z, v2.Z, v3.Z)));
-                Assert.AreEqual(Vector3.Cross(v1, v2),
-                    new Vector3(v1.Y * v2.Z - v1.Z * v2.Y, v1.Z * v2.X - v1.X * v2.Z, v1.X * v2.Y - v1.Y * v2.X));
+                Assert.AreEqual(Vector3.Clamp(v1, v2, v3), new Vector3(Clamp(v1.X, v2.X, v3.X), Clamp(v1.Y, v2.Y, v3.Y), Clamp(v1.Z, v2.Z, v3.Z)));
+                Assert.AreEqual(Vector3.Cross(v1, v2), new Vector3(v1.Y * v2.Z - v1.Z * v2.Y, v1.Z * v2.X - v1.X * v2.Z, v1.X * v2.Y - v1.Y * v2.X));
 #if USE_NUMERICS
                 Assert.IsTrue(CloseEnough(Vector3.Distance(v1, v2), (v1 - v2).Length()));
 #else
@@ -86,10 +82,8 @@ namespace OpenGLUnitTests
                 Assert.AreEqual(Vector3.Divide(v1, v2), new Vector3(v1.X / v2.X, v1.Y / v2.Y, v1.Z / v2.Z));
                 Assert.IsTrue(CloseEnough(Vector3.Dot(v1, v2), v1.X * v2.X + v1.Y * v2.Y + v1.Z * v2.Z));
                 Assert.IsTrue(CloseEnough(Vector3.Lerp(v1, v2, f1), v1 + (v2 - v1) * f1, 1e-02f));
-                Assert.AreEqual(Vector3.Max(v1, v2),
-                    new Vector3(Math.Max(v1.X, v2.X), Math.Max(v1.Y, v2.Y), Math.Max(v1.Z, v2.Z)));
-                Assert.AreEqual(Vector3.Min(v1, v2),
-                    new Vector3(Math.Min(v1.X, v2.X), Math.Min(v1.Y, v2.Y), Math.Min(v1.Z, v2.Z)));
+                Assert.AreEqual(Vector3.Max(v1, v2), new Vector3(Math.Max(v1.X, v2.X), Math.Max(v1.Y, v2.Y), Math.Max(v1.Z, v2.Z)));
+                Assert.AreEqual(Vector3.Min(v1, v2), new Vector3(Math.Min(v1.X, v2.X), Math.Min(v1.Y, v2.Y), Math.Min(v1.Z, v2.Z)));
                 Assert.AreEqual(Vector3.Multiply(v1, f1), new Vector3(v1.X * f1, v1.Y * f1, v1.Z * f1));
                 Assert.AreEqual(Vector3.Multiply(f1, v1), new Vector3(v1.X * f1, v1.Y * f1, v1.Z * f1));
                 Assert.AreEqual(Vector3.Multiply(v1, v2), new Vector3(v1.X * v2.X, v1.Y * v2.Y, v1.Z * v2.Z));
@@ -100,8 +94,7 @@ namespace OpenGLUnitTests
                 Assert.AreEqual(Vector3.Normalize(v1), v1 / v1.Length());
 #endif
                 Assert.IsTrue(CloseEnough(Vector3.Reflect(v1, v2), v1 - Vector3.Dot(v1, v2) * v2 * 2f));
-                Assert.IsTrue(CloseEnough(Vector3.SquareRoot(v1),
-                    new Vector3((float) Math.Sqrt(v1.X), (float) Math.Sqrt(v1.Y), (float) Math.Sqrt(v1.Z))));
+                Assert.IsTrue(CloseEnough(Vector3.SquareRoot(v1), new Vector3((float)Math.Sqrt(v1.X), (float)Math.Sqrt(v1.Y), (float)Math.Sqrt(v1.Z))));
                 Assert.AreEqual(Vector3.Subtract(v1, v2), new Vector3(v1.X - v2.X, v1.Y - v2.Y, v1.Z - v2.Z));
                 Assert.IsTrue(CloseEnough(Vector3.Transform(v1, q), Transform(v1, q), 1e-01f));
             }
@@ -111,7 +104,7 @@ namespace OpenGLUnitTests
 
         private float GetRandomFloat()
         {
-            return (float) (10000 * (generator.NextDouble() - 0.5));
+            return (float)(10000 * (generator.NextDouble() - 0.5));
         }
 
         private float Clamp(float value, float min, float max)
@@ -129,11 +122,10 @@ namespace OpenGLUnitTests
 
         private bool CloseEnough(Vector3 v1, Vector3 v2, float rtol = 1e-05f)
         {
-            bool close = CloseEnough(v1.X, v2.X, rtol) && CloseEnough(v1.Y, v2.Y, rtol) &&
-                         CloseEnough(v1.Z, v2.Z, rtol);
+            bool close = CloseEnough(v1.X, v2.X, rtol) && CloseEnough(v1.Y, v2.Y, rtol) && CloseEnough(v1.Z, v2.Z, rtol);
 
             if (close) return true;
-            else
+            else 
                 return false;
         }
 

--- a/OpenGLUnitTests/Vector3Tests.cs
+++ b/OpenGLUnitTests/Vector3Tests.cs
@@ -3,9 +3,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #if USE_NUMERICS
 using System.Numerics;
-#else
-using OpenGL;
 #endif
+using OpenGL;
 
 namespace OpenGLUnitTests
 {
@@ -51,6 +50,7 @@ namespace OpenGLUnitTests
             }
         }
 #endif
+
         [TestMethod]
         public void Vector3StaticMethods()
         {

--- a/OpenGLUnitTests/Vector3Tests.cs
+++ b/OpenGLUnitTests/Vector3Tests.cs
@@ -3,8 +3,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #if USE_NUMERICS
 using System.Numerics;
-#endif
+#else
 using OpenGL;
+#endif
 
 namespace OpenGLUnitTests
 {

--- a/OpenGLUnitTests/Vector3Tests.cs
+++ b/OpenGLUnitTests/Vector3Tests.cs
@@ -46,10 +46,7 @@ namespace OpenGLUnitTests
                 Vector3 v1 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
                 Vector3 v2 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
                 Vector3 a = v1;
-
-               a.TakeMax(v2);
-
-
+                a.TakeMax(v2);
                 Assert.AreEqual(a, new Vector3(Math.Max(v1.X, v2.X), Math.Max(v1.Y, v2.Y), Math.Max(v1.Z, v2.Z)));
             }
         }

--- a/OpenGLUnitTests/Vector3Tests.cs
+++ b/OpenGLUnitTests/Vector3Tests.cs
@@ -1,12 +1,11 @@
-﻿#define USE_NUMERICS
-
-using System;
+﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #if USE_NUMERICS
 using System.Numerics;
-#endif
+#else
 using OpenGL;
+#endif
 
 namespace OpenGLUnitTests
 {
@@ -23,6 +22,7 @@ namespace OpenGLUnitTests
             Assert.AreEqual(Vector3.Zero, new Vector3(0, 0, 0));
         }
 
+#if !USE_NUMERICS
         [TestMethod]
         public void Vector3TakeMin()
         {
@@ -31,11 +31,15 @@ namespace OpenGLUnitTests
                 Vector3 v1 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
                 Vector3 v2 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
                 Vector3 a = v1;
+
                 a.TakeMin(v2);
+
                 Assert.AreEqual(a, new Vector3(Math.Min(v1.X, v2.X), Math.Min(v1.Y, v2.Y), Math.Min(v1.Z, v2.Z)));
             }
         }
-
+#endif
+       
+#if !USE_NUMERICS
         [TestMethod]
         public void Vector3TakeMax()
         {
@@ -44,11 +48,14 @@ namespace OpenGLUnitTests
                 Vector3 v1 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
                 Vector3 v2 = new Vector3(GetRandomFloat(), GetRandomFloat(), GetRandomFloat());
                 Vector3 a = v1;
-                a.TakeMax(v2);
+
+               a.TakeMax(v2);
+
+
                 Assert.AreEqual(a, new Vector3(Math.Max(v1.X, v2.X), Math.Max(v1.Y, v2.Y), Math.Max(v1.Z, v2.Z)));
             }
         }
-
+#endif
         [TestMethod]
         public void Vector3StaticMethods()
         {
@@ -65,20 +72,24 @@ namespace OpenGLUnitTests
 
                 Assert.AreEqual(Vector3.Abs(v1), new Vector3(Math.Abs(v1.X), Math.Abs(v1.Y), Math.Abs(v1.Z)));
                 Assert.AreEqual(Vector3.Add(v1, v2), new Vector3(v1.X + v2.X, v1.Y + v2.Y, v1.Z + v2.Z));
-                Assert.AreEqual(Vector3.Clamp(v1, v2, v3), new Vector3(Clamp(v1.X, v2.X, v3.X), Clamp(v1.Y, v2.Y, v3.Y), Clamp(v1.Z, v2.Z, v3.Z)));
-                Assert.AreEqual(Vector3.Cross(v1, v2), new Vector3(v1.Y * v2.Z - v1.Z * v2.Y, v1.Z * v2.X - v1.X * v2.Z, v1.X * v2.Y - v1.Y * v2.X));
+                Assert.AreEqual(Vector3.Clamp(v1, v2, v3),
+                    new Vector3(Clamp(v1.X, v2.X, v3.X), Clamp(v1.Y, v2.Y, v3.Y), Clamp(v1.Z, v2.Z, v3.Z)));
+                Assert.AreEqual(Vector3.Cross(v1, v2),
+                    new Vector3(v1.Y * v2.Z - v1.Z * v2.Y, v1.Z * v2.X - v1.X * v2.Z, v1.X * v2.Y - v1.Y * v2.X));
 #if USE_NUMERICS
                 Assert.IsTrue(CloseEnough(Vector3.Distance(v1, v2), (v1 - v2).Length()));
 #else
-                Assert.IsTrue(CloseEnough(Vector3.Distance(v1, v2), (v1 - v2).Length));
+                Assert.IsTrue(CloseEnough(Vector3.Distance(v1, v2), (v1 - v2).Length()));
 #endif
                 Assert.IsTrue(CloseEnough(Vector3.DistanceSquared(v1, v2), (v1 - v2).LengthSquared()));
                 Assert.AreEqual(Vector3.Divide(v1, f1), new Vector3(v1.X / f1, v1.Y / f1, v1.Z / f1));
                 Assert.AreEqual(Vector3.Divide(v1, v2), new Vector3(v1.X / v2.X, v1.Y / v2.Y, v1.Z / v2.Z));
                 Assert.IsTrue(CloseEnough(Vector3.Dot(v1, v2), v1.X * v2.X + v1.Y * v2.Y + v1.Z * v2.Z));
                 Assert.IsTrue(CloseEnough(Vector3.Lerp(v1, v2, f1), v1 + (v2 - v1) * f1, 1e-02f));
-                Assert.AreEqual(Vector3.Max(v1, v2), new Vector3(Math.Max(v1.X, v2.X), Math.Max(v1.Y, v2.Y), Math.Max(v1.Z, v2.Z)));
-                Assert.AreEqual(Vector3.Min(v1, v2), new Vector3(Math.Min(v1.X, v2.X), Math.Min(v1.Y, v2.Y), Math.Min(v1.Z, v2.Z)));
+                Assert.AreEqual(Vector3.Max(v1, v2),
+                    new Vector3(Math.Max(v1.X, v2.X), Math.Max(v1.Y, v2.Y), Math.Max(v1.Z, v2.Z)));
+                Assert.AreEqual(Vector3.Min(v1, v2),
+                    new Vector3(Math.Min(v1.X, v2.X), Math.Min(v1.Y, v2.Y), Math.Min(v1.Z, v2.Z)));
                 Assert.AreEqual(Vector3.Multiply(v1, f1), new Vector3(v1.X * f1, v1.Y * f1, v1.Z * f1));
                 Assert.AreEqual(Vector3.Multiply(f1, v1), new Vector3(v1.X * f1, v1.Y * f1, v1.Z * f1));
                 Assert.AreEqual(Vector3.Multiply(v1, v2), new Vector3(v1.X * v2.X, v1.Y * v2.Y, v1.Z * v2.Z));
@@ -86,10 +97,11 @@ namespace OpenGLUnitTests
 #if USE_NUMERICS
                 Assert.AreEqual(Vector3.Normalize(v1), v1 / v1.Length());
 #else
-                Assert.AreEqual(Vector3.Normalize(v1), v1 / v1.Length);
+                Assert.AreEqual(Vector3.Normalize(v1), v1 / v1.Length());
 #endif
                 Assert.IsTrue(CloseEnough(Vector3.Reflect(v1, v2), v1 - Vector3.Dot(v1, v2) * v2 * 2f));
-                Assert.IsTrue(CloseEnough(Vector3.SquareRoot(v1), new Vector3((float)Math.Sqrt(v1.X), (float)Math.Sqrt(v1.Y), (float)Math.Sqrt(v1.Z))));
+                Assert.IsTrue(CloseEnough(Vector3.SquareRoot(v1),
+                    new Vector3((float) Math.Sqrt(v1.X), (float) Math.Sqrt(v1.Y), (float) Math.Sqrt(v1.Z))));
                 Assert.AreEqual(Vector3.Subtract(v1, v2), new Vector3(v1.X - v2.X, v1.Y - v2.Y, v1.Z - v2.Z));
                 Assert.IsTrue(CloseEnough(Vector3.Transform(v1, q), Transform(v1, q), 1e-01f));
             }
@@ -99,7 +111,7 @@ namespace OpenGLUnitTests
 
         private float GetRandomFloat()
         {
-            return (float)(10000 * (generator.NextDouble() - 0.5));
+            return (float) (10000 * (generator.NextDouble() - 0.5));
         }
 
         private float Clamp(float value, float min, float max)
@@ -117,10 +129,11 @@ namespace OpenGLUnitTests
 
         private bool CloseEnough(Vector3 v1, Vector3 v2, float rtol = 1e-05f)
         {
-            bool close = CloseEnough(v1.X, v2.X, rtol) && CloseEnough(v1.Y, v2.Y, rtol) && CloseEnough(v1.Z, v2.Z, rtol);
+            bool close = CloseEnough(v1.X, v2.X, rtol) && CloseEnough(v1.Y, v2.Y, rtol) &&
+                         CloseEnough(v1.Z, v2.Z, rtol);
 
             if (close) return true;
-            else 
+            else
                 return false;
         }
 


### PR DESCRIPTION
### Matrix multiplication - Matrix4 x Matrix4 x Matrix4
While doing a small project I noticed that Matrix4 * Matrix4 multiplication wasn't working as I would expect. When I was multiplying my model, view and projection Matrix I got some weird results. Normally you read matrix multiplication from right to the left. Like this for example "projection * view * model".  But this wasn't the case with the current implementation.
In my opinion this is unexpected and wrong behaviour. 
I corrected that.

### Tests
Additionally I added a test case to make sure this behaviour can be tested.
Besides that I tried to fix the tests because they seemed abandoned? I added a solution configuration for "Use_numerics" and added additional preprocessor directives. You can use the normal solution configuration to test without System.Numerics. All tests are passing with both configurations. (Note: Vector3StaticMethods seems to fail sometimes. But that behaviour was already there before my changes)

For determining the test results I used a online calculator. See the following links for the result:
[m3 * result(m1 * m2)](https://matrixcalc.org/de/#%7B%7B220,230,190,100%7D,%7B740,710,630,500%7D,%7B1260,1190,1070,900%7D,%7B1780,1670,1510,1300%7D%7D*%7B%7B100,200,300,400%7D,%7B500,100,200,300%7D,%7B400,500,100,200%7D,%7B300,400,500,100%7D%7D)
[m2 * m1](https://matrixcalc.org/de/#%7B%7B0,1,2,3%7D,%7B4,5,6,7%7D,%7B8,9,10,11%7D,%7B12,13,14,15%7D%7D*%7B%7B10,20,30,40%7D,%7B50,10,20,30%7D,%7B40,50,10,20%7D,%7B30,40,50,10%7D%7D)
![MatrixMultiplication](https://user-images.githubusercontent.com/33264067/177798421-9fd33fe2-fad1-4e11-a8e0-8c1ce219bd9a.png)

Let me know what you think! Thanks for the Library btw. 